### PR TITLE
Fix type-only imports and add coverage for jobs fetching

### DIFF
--- a/web/README.md
+++ b/web/README.md
@@ -10,6 +10,7 @@ across the Middle East by reading a JSON feed stored in Cloudflare R2.
 - 📊 **Market signals** – Summaries of active companies, cross-country coverage, and in-demand technologies.
 - ☁️ **Cloudflare ready** – Designed for static deployment with data delivered from R2 via `VITE_JOBS_DATA_URL`.
 - ✅ **Quality assured** – Includes unit and integration tests powered by Vitest and Testing Library.
+- 🛡️ **Resilient data ingest** – Normalises Cloudflare R2 payloads and defends against network failures with tested fallbacks.
 
 ## Getting started locally
 
@@ -52,6 +53,13 @@ Run the full suite before every commit/deployment:
 ```bash
 npm test
 ```
+
+## Development notes
+
+- The project opts into TypeScript's `verbatimModuleSyntax`, so type-only imports **must** use `import type { ... }` to
+  keep the build green.
+- Vitest configuration lives in `vite.config.ts` and is typed via Vitest's `InlineConfig`, keeping Vite and Vitest settings
+  in one place.
 
 ## Deployment on Cloudflare Pages
 

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -5,7 +5,7 @@ import { JobCard } from './components/JobCard'
 import { SkillHighlights } from './components/SkillHighlights'
 import { SummaryMetrics } from './components/SummaryMetrics'
 import { fetchJobs } from './services/jobsService'
-import { Job, JobFilters } from './types/job'
+import type { Job, JobFilters } from './types/job'
 import {
   applyFilters,
   defaultFilters,

--- a/web/src/__tests__/App.integration.test.tsx
+++ b/web/src/__tests__/App.integration.test.tsx
@@ -1,0 +1,63 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import App from '../App'
+
+describe('App integration', () => {
+  let fetchMock: ReturnType<typeof vi.fn>
+  const originalJobsUrl = import.meta.env.VITE_JOBS_DATA_URL
+
+  beforeEach(() => {
+    vi.resetAllMocks()
+    fetchMock = vi.fn()
+    vi.stubGlobal('fetch', fetchMock)
+    ;(import.meta.env as Record<string, string>).VITE_JOBS_DATA_URL = 'https://example.com/jobs.json'
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    if (originalJobsUrl === undefined) {
+      delete (import.meta.env as Record<string, string | undefined>).VITE_JOBS_DATA_URL
+    } else {
+      ;(import.meta.env as Record<string, string>).VITE_JOBS_DATA_URL = originalJobsUrl
+    }
+  })
+
+  it('renders fetched jobs and derived metrics', async () => {
+    const payload = [
+      {
+        job_hash: 'job-123',
+        title: 'Lead Analytics Engineer',
+        company: 'Insight Labs',
+        location: 'Doha, Qatar',
+        job_type: 'Full-time',
+        is_remote: false,
+        desired_tech_skills_inferred: 'dbt, Snowflake',
+      },
+    ]
+
+    fetchMock.mockResolvedValue({
+      ok: true,
+      json: async () => payload,
+    })
+
+    render(<App />)
+
+    await waitFor(() => {
+      expect(screen.getByText('Lead Analytics Engineer')).toBeInTheDocument()
+    })
+
+    expect(screen.getByText('Insight Labs')).toBeInTheDocument()
+    expect(screen.getByText('Showing 1 roles')).toBeInTheDocument()
+    expect(screen.getAllByText('Doha, Qatar')[0]).toBeInTheDocument()
+  })
+
+  it('displays an error message when fetching jobs fails', async () => {
+    fetchMock.mockRejectedValue(new Error('Network unavailable'))
+
+    render(<App />)
+
+    await waitFor(() => {
+      expect(screen.getByRole('alert')).toHaveTextContent('Network unavailable')
+    })
+  })
+})

--- a/web/src/__tests__/jobFilters.test.ts
+++ b/web/src/__tests__/jobFilters.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { Job, JobFilters } from '../types/job'
+import type { Job, JobFilters } from '../types/job'
 import { applyFilters, defaultFilters } from '../utils/jobFilters'
 
 const createJob = (overrides: Partial<Job> = {}): Job => ({

--- a/web/src/__tests__/jobsService.test.ts
+++ b/web/src/__tests__/jobsService.test.ts
@@ -1,0 +1,97 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { fetchJobs, normaliseJobs } from '../services/jobsService'
+
+describe('normaliseJobs', () => {
+  it('returns an empty array when payload is nullish', () => {
+    expect(normaliseJobs(undefined)).toEqual([])
+    expect(normaliseJobs(null)).toEqual([])
+  })
+
+  it('normalises raw job entries into the expected structure', () => {
+    const result = normaliseJobs([
+      {
+        job_hash: 'abc123',
+        title: 'Principal Data Engineer',
+        company: 'Cloud Analytics',
+        location: 'Dubai, United Arab Emirates',
+        job_type: 'Full-time',
+        date_posted: '2025-01-01',
+        is_remote: 'true',
+        desired_tech_skills_inferred: 'Python, Spark, Airflow',
+        desired_domain_skills_inferred: 'Data Warehousing',
+        desired_soft_skills_inferred: 'Communication',
+      },
+    ])
+
+    expect(result).toHaveLength(1)
+    expect(result[0]).toMatchObject({
+      id: 'abc123',
+      title: 'Principal Data Engineer',
+      company: 'Cloud Analytics',
+      jobType: 'Full-time',
+      postingDate: '2025-01-01',
+      isRemote: true,
+      techSkills: ['Python', 'Spark', 'Airflow'],
+      domainSkills: ['Data Warehousing'],
+      softSkills: ['Communication'],
+    })
+  })
+})
+
+describe('fetchJobs', () => {
+  beforeEach(() => {
+    vi.resetAllMocks()
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('retrieves and normalises jobs from the provided URL', async () => {
+    const payload = [
+      {
+        job_hash: 'job-1',
+        title: 'Staff Data Engineer',
+        company: 'Data Corp',
+        location: 'Riyadh, Saudi Arabia',
+      },
+    ]
+
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => payload,
+    })
+
+    vi.stubGlobal('fetch', fetchMock)
+
+    const result = await fetchJobs('https://example.com/jobs.json')
+
+    expect(fetchMock).toHaveBeenCalledWith('https://example.com/jobs.json')
+    expect(result).toHaveLength(1)
+    expect(result[0]).toMatchObject({
+      id: 'job-1',
+      title: 'Staff Data Engineer',
+      company: 'Data Corp',
+      location: 'Riyadh, Saudi Arabia',
+    })
+  })
+
+  it('throws a helpful error when fetch returns a non-ok response', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 500,
+    })
+
+    vi.stubGlobal('fetch', fetchMock)
+
+    await expect(fetchJobs('https://example.com/jobs.json')).rejects.toThrow(
+      'Unable to fetch jobs data (status 500)',
+    )
+  })
+
+  it('throws when the jobs URL is missing', async () => {
+    await expect(fetchJobs('')).rejects.toThrow(
+      'Jobs data URL is not configured. Set VITE_JOBS_DATA_URL in your environment.',
+    )
+  })
+})

--- a/web/src/components/FilterBar.tsx
+++ b/web/src/components/FilterBar.tsx
@@ -1,5 +1,5 @@
-import { ChangeEvent } from 'react'
-import { JobFilters } from '../types/job'
+import type { ChangeEvent } from 'react'
+import type { JobFilters } from '../types/job'
 
 interface FilterBarProps {
   filters: JobFilters

--- a/web/src/components/JobCard.tsx
+++ b/web/src/components/JobCard.tsx
@@ -1,4 +1,4 @@
-import { Job } from '../types/job'
+import type { Job } from '../types/job'
 
 const formatDate = (value?: string | null): string => {
   if (!value) {

--- a/web/src/components/SkillHighlights.tsx
+++ b/web/src/components/SkillHighlights.tsx
@@ -1,4 +1,4 @@
-import { SkillFrequency } from '../utils/skills'
+import type { SkillFrequency } from '../utils/skills'
 
 interface SkillHighlightsProps {
   skills: SkillFrequency[]

--- a/web/src/services/jobsService.ts
+++ b/web/src/services/jobsService.ts
@@ -1,4 +1,4 @@
-import { Job } from '../types/job'
+import type { Job } from '../types/job'
 import { parseSkillList } from '../utils/skills'
 
 type RawJob = Record<string, unknown>

--- a/web/src/utils/jobFilters.ts
+++ b/web/src/utils/jobFilters.ts
@@ -1,4 +1,4 @@
-import { Job, JobFilters } from '../types/job'
+import type { Job, JobFilters } from '../types/job'
 
 export const defaultFilters: JobFilters = {
   searchTerm: '',

--- a/web/src/utils/skills.ts
+++ b/web/src/utils/skills.ts
@@ -1,4 +1,4 @@
-import { Job } from '../types/job'
+import type { Job } from '../types/job'
 
 const SKILL_DELIMITERS = /,|\n|\||;|\//
 

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -1,8 +1,10 @@
 import { defineConfig } from 'vite'
+import type { UserConfig } from 'vite'
+import type { InlineConfig } from 'vitest'
 import react from '@vitejs/plugin-react'
 
 // https://vite.dev/config/
-export default defineConfig({
+const config: UserConfig & { test: InlineConfig } = {
   plugins: [react()],
   test: {
     environment: 'jsdom',
@@ -10,4 +12,6 @@ export default defineConfig({
     globals: true,
     css: true,
   },
-})
+}
+
+export default defineConfig(config)


### PR DESCRIPTION
## Summary
- use TypeScript type-only imports across components and utilities to satisfy verbatimModuleSyntax
- type the shared Vite/Vitest configuration so test settings are recognised during the build
- add jobs service and app integration tests and document the stricter build requirements in the README

## Testing
- npm run build
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e32b66482c83328d8397808f563313