### PR TITLE
Improve hero responsiveness and focus on actionable content

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,8 @@
 
 This repository hosts a modern single-page application that spotlights data engineering opportunities across the Middle
 East. The site is designed to run as a static Cloudflare Pages deployment while sourcing live job listings from a JSON
-object stored in Cloudflare R2.
+object stored in Cloudflare R2. The landing experience is now streamlined for actionable content and adapts fluidly to
+mobile screens so job seekers can triage roles on the go.
 
 ## Project structure
 

--- a/web/README.md
+++ b/web/README.md
@@ -6,6 +6,7 @@ across the Middle East by reading a JSON feed stored in Cloudflare R2.
 ## Features
 
 - 🎯 **Focused experience** – Highlights data engineering roles with company, location, and posting insights.
+- 📱 **Mobile-first design** – Responsive layout keeps the filters and results easy to read on phones and tablets.
 - 🔍 **Powerful filters** – Search by keyword, limit by country, job type, or remote-friendly opportunities.
 - 📊 **Market signals** – Summaries of active companies, cross-country coverage, and in-demand technologies.
 - ☁️ **Cloudflare ready** – Designed for static deployment with data delivered from R2 via `VITE_JOBS_DATA_URL`.

--- a/web/src/App.css
+++ b/web/src/App.css
@@ -4,13 +4,54 @@
 
 .hero {
   background: linear-gradient(135deg, #0049ff, #6f73ff);
+  position: relative;
+  overflow: hidden;
 }
 
-.hero code {
-  background: rgba(255, 255, 255, 0.15);
-  color: #fff;
-  padding: 0.25rem 0.5rem;
+.hero::after {
+  content: '';
+  position: absolute;
+  inset: -30% -20% auto auto;
+  width: 18rem;
+  height: 18rem;
+  background: radial-gradient(circle at center, rgba(255, 255, 255, 0.45), transparent 70%);
+  opacity: 0.6;
+  pointer-events: none;
+}
+
+.hero__title {
+  font-size: clamp(2rem, 3vw + 1rem, 3.25rem);
+  line-height: 1.1;
+}
+
+.hero__subtitle {
+  max-width: 40rem;
+  margin: 0 auto;
+}
+
+.hero__actions-note {
+  max-width: 18rem;
+}
+
+.hero-highlight {
+  border: 1px solid rgba(13, 110, 253, 0.12);
+  backdrop-filter: blur(4px);
+}
+
+.hero-highlight__list li {
+  padding-left: 1.5rem;
+  position: relative;
+}
+
+.hero-highlight__list li::before {
+  content: '';
+  position: absolute;
+  left: 0;
+  top: 0.6rem;
+  width: 0.55rem;
+  height: 0.55rem;
   border-radius: 999px;
+  background: linear-gradient(135deg, #3a7bff, #0049ff);
 }
 
 .filter-bar {
@@ -29,4 +70,44 @@
 
 footer {
   background-color: rgba(255, 255, 255, 0.6);
+}
+
+@media (min-width: 992px) {
+  .hero__subtitle {
+    margin: 0;
+  }
+
+  .hero__actions-note {
+    max-width: 22rem;
+  }
+}
+
+@media (max-width: 767.98px) {
+  .hero::after {
+    inset: auto -40% -20% auto;
+    width: 14rem;
+    height: 14rem;
+  }
+
+  .hero-highlight {
+    background-color: rgba(255, 255, 255, 0.9);
+  }
+}
+
+@media (max-width: 575.98px) {
+  .hero {
+    border-radius: 1.5rem;
+  }
+
+  .hero__actions {
+    align-items: stretch !important;
+  }
+
+  .hero__actions-note {
+    max-width: none;
+  }
+
+  .hero-highlight {
+    padding: 1.5rem;
+  }
 }

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -74,26 +74,44 @@ function App() {
 
   return (
     <div className="app bg-body-tertiary min-vh-100">
-      <main className="py-5">
+      <main className="py-4 py-md-5">
         <div className="container-lg">
-          <header className="hero bg-primary text-white rounded-5 p-5 mb-5 shadow-sm">
+          <header className="hero bg-primary text-white rounded-5 p-4 p-lg-5 mb-5 shadow-sm">
             <div className="row align-items-center g-4">
-              <div className="col-lg-8">
+              <div className="col-lg-7 col-xl-6 text-center text-lg-start">
                 <span className="badge bg-white text-primary fw-semibold text-uppercase mb-3">
                   Middle East · Data Engineering
                 </span>
-                <h1 className="display-5 fw-bold mb-3">
-                  Discover high-impact data engineering roles across the Middle East
+                <h1 className="hero__title fw-bold mb-3">
+                  Find your next data engineering role in minutes
                 </h1>
-                <p className="lead mb-4">
-                  Curated opportunities sourced from Cloudflare R2 to help data engineers find their next career move in
-                  Riyadh, Dubai, Doha, and beyond.
+                <p className="hero__subtitle lead mb-4 text-white-50">
+                  Browse vetted opportunities from Riyadh to Dubai and instantly filter by location, contract type, or
+                  remote-friendly roles.
                 </p>
-                <p className="mb-0 text-white-50">
-                  Keep this page deployed on Cloudflare Pages and configure the{' '}
-                  <code>VITE_JOBS_DATA_URL</code> variable with your R2 JSON file to stay in sync with the latest market
-                  demand.
-                </p>
+                <div className="hero__actions d-flex flex-column flex-sm-row gap-3 align-items-stretch align-items-sm-center">
+                  <a className="btn btn-light btn-lg text-primary fw-semibold shadow-sm" href="#job-results">
+                    Browse open roles
+                  </a>
+                  <div className="hero__actions-note small text-white-50">
+                    <span className="d-block fw-semibold text-white">Focused results</span>
+                    Zero fluff—just the roles and filters you need to plan your next move.
+                  </div>
+                </div>
+              </div>
+              <div className="col-lg-5 col-xl-4 ms-lg-auto">
+                <div className="hero-highlight bg-white text-primary-emphasis rounded-4 shadow-sm p-4">
+                  <h2 className="h5 fw-semibold mb-3">Why professionals use this board</h2>
+                  <ul className="hero-highlight__list list-unstyled mb-0 d-grid gap-2">
+                    <li>
+                      Live metrics summarise total, remote, and company coverage so you can prioritise outreach quickly.
+                    </li>
+                    <li>
+                      Instant keyword search keeps the focus on tools that matter—dbt, Spark, Snowflake, and more.
+                    </li>
+                    <li>Mobile-first layout lets you triage opportunities on the go.</li>
+                  </ul>
+                </div>
               </div>
             </div>
           </header>
@@ -124,7 +142,10 @@ function App() {
 
           <SkillHighlights skills={skillFrequency} />
 
-          <section className="d-flex justify-content-between align-items-center mb-3 flex-wrap gap-2">
+          <section
+            id="job-results"
+            className="job-results__header d-flex justify-content-between align-items-center mb-3 flex-wrap gap-2"
+          >
             <h2 className="h4 mb-0">{isLoading ? 'Loading roles…' : `Showing ${filteredJobs.length} roles`}</h2>
             {!isLoading && jobs.length !== filteredJobs.length && (
               <span className="badge bg-secondary-subtle text-secondary-emphasis rounded-pill px-3 py-2">

--- a/web/src/__tests__/App.test.tsx
+++ b/web/src/__tests__/App.test.tsx
@@ -48,6 +48,20 @@ describe('App', () => {
     vi.restoreAllMocks()
   })
 
+  it('shows a focused hero message with a call to action', async () => {
+    render(<App />)
+
+    expect(
+      await screen.findByRole('link', {
+        name: /browse open roles/i,
+      }),
+    ).toHaveAttribute('href', '#job-results')
+
+    expect(
+      await screen.findByText(/live metrics summarise total, remote, and company coverage/i),
+    ).toBeInTheDocument()
+  })
+
   it('renders job cards after fetching data', async () => {
     render(<App />)
 


### PR DESCRIPTION
## Summary
- streamline the landing hero with actionable copy, a clear CTA, and a supporting highlight card for job seekers
- introduce responsive hero styling tuned for small screens while trimming unused desktop-specific code
- document the mobile-first improvements and add a unit test to cover the new hero content

## Testing
- npm test
- npx vitest run --reporter=basic

------
https://chatgpt.com/codex/tasks/task_e_68e4ae1cfba4833292f798616a4c1666