### PR TITLE
Add analytics dashboard and enhance filtering experience

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,14 @@
 
 This repository hosts a modern single-page application that spotlights data engineering opportunities across the Middle
 East. The site is designed to run as a static Cloudflare Pages deployment while sourcing live job listings from a JSON
-object stored in Cloudflare R2. The landing experience is now streamlined for actionable content and adapts fluidly to
-mobile screens so job seekers can triage roles on the go.
+object stored in Cloudflare R2. The landing experience is streamlined for actionable content, introduces an analytics
+dashboard with hiring trends, and adapts fluidly to mobile screens so job seekers can triage roles on the go.
+
+## Highlights
+
+- 🔍 Multi-select keyword search with autocomplete suggestions spanning job titles, companies, and in-demand skills.
+- 🗓️ Posting date filters (24 hours, 3 days, 1 week, 2 weeks) to surface the freshest opportunities instantly.
+- 📊 Dedicated analytics page summarising market metrics, recent hiring companies, and skills momentum.
 
 ## Project structure
 

--- a/web/README.md
+++ b/web/README.md
@@ -7,8 +7,8 @@ across the Middle East by reading a JSON feed stored in Cloudflare R2.
 
 - 🎯 **Focused experience** – Highlights data engineering roles with company, location, and posting insights.
 - 📱 **Mobile-first design** – Responsive layout keeps the filters and results easy to read on phones and tablets.
-- 🔍 **Powerful filters** – Search by keyword, limit by country, job type, or remote-friendly opportunities.
-- 📊 **Market signals** – Summaries of active companies, cross-country coverage, and in-demand technologies.
+- 🔍 **Powerful filters** – Multi-select keyword search with autocomplete, country filtering, and posting date controls.
+- 📊 **Market signals** – Dedicated analytics dashboard with hiring momentum, cross-country coverage, and in-demand technologies.
 - ☁️ **Cloudflare ready** – Designed for static deployment with data delivered from R2 via `VITE_JOBS_DATA_URL`.
 - ✅ **Quality assured** – Includes unit and integration tests powered by Vitest and Testing Library.
 - 🛡️ **Resilient data ingest** – Normalises Cloudflare R2 payloads and defends against network failures with tested fallbacks.
@@ -55,7 +55,7 @@ the user for this exercise is `https://6d9a56e137a3328cc52e48656dd30d91.r2.cloud
 
 - **Unit tests** cover the filtering logic to guarantee consistent search and filter behaviour.
 - **Integration tests** render the full application, mock the R2 fetch call, and validate that user flows (search and
-  remote-only filtering) operate end-to-end.
+  posting-date filtering) operate end-to-end.
 
 Run the full suite before every commit/deployment:
 

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -10,7 +10,8 @@
       "dependencies": {
         "bootstrap": "^5.3.3",
         "react": "^19.1.1",
-        "react-dom": "^19.1.1"
+        "react-dom": "^19.1.1",
+        "react-router-dom": "^6.30.1"
       },
       "devDependencies": {
         "@eslint/js": "^9.36.0",
@@ -1215,6 +1216,15 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/popperjs"
+      }
+    },
+    "node_modules/@remix-run/router": {
+      "version": "1.23.0",
+      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.23.0.tgz",
+      "integrity": "sha512-O3rHJzAQKamUz1fvE0Qaw0xSFqsA/yafi2iqeE0pvdFtCO1viYx8QL6f3Ln/aCCTLxs68SLf0KPM9eSeM8yBnA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@rolldown/pluginutils": {
@@ -3718,6 +3728,38 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-router": {
+      "version": "6.30.1",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.30.1.tgz",
+      "integrity": "sha512-X1m21aEmxGXqENEPG3T6u0Th7g0aS4ZmoNynhbs+Cn+q+QGTLt+d5IQ2bHAXKzKcxGJjxACpVbnYQSCRcfxHlQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@remix-run/router": "1.23.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8"
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "6.30.1",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.30.1.tgz",
+      "integrity": "sha512-llKsgOkZdbPU1Eg3zK8lCn+sjD9wMRZZPuzmdWWX5SUs8OFkN5HnFVC0u5KMeMaC9aoancFI/KoLuKPqN+hxHw==",
+      "license": "MIT",
+      "dependencies": {
+        "@remix-run/router": "1.23.0",
+        "react-router": "6.30.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
       }
     },
     "node_modules/redent": {

--- a/web/package.json
+++ b/web/package.json
@@ -14,7 +14,8 @@
   "dependencies": {
     "bootstrap": "^5.3.3",
     "react": "^19.1.1",
-    "react-dom": "^19.1.1"
+    "react-dom": "^19.1.1",
+    "react-router-dom": "^6.30.1"
   },
   "devDependencies": {
     "@eslint/js": "^9.36.0",

--- a/web/src/App.css
+++ b/web/src/App.css
@@ -33,27 +33,6 @@
   max-width: 18rem;
 }
 
-.hero-highlight {
-  border: 1px solid rgba(13, 110, 253, 0.12);
-  backdrop-filter: blur(4px);
-}
-
-.hero-highlight__list li {
-  padding-left: 1.5rem;
-  position: relative;
-}
-
-.hero-highlight__list li::before {
-  content: '';
-  position: absolute;
-  left: 0;
-  top: 0.6rem;
-  width: 0.55rem;
-  height: 0.55rem;
-  border-radius: 999px;
-  background: linear-gradient(135deg, #3a7bff, #0049ff);
-}
-
 .filter-bar {
   backdrop-filter: blur(8px);
 }
@@ -72,6 +51,26 @@ footer {
   background-color: rgba(255, 255, 255, 0.6);
 }
 
+.search-multi-select__input {
+  min-width: 12rem;
+  outline: none;
+}
+
+.search-multi-select__input:focus {
+  outline: none;
+}
+
+.btn-close-sm {
+  width: 0.75rem;
+  height: 0.75rem;
+  padding: 0;
+  filter: invert(29%) sepia(82%) saturate(3175%) hue-rotate(212deg) brightness(92%) contrast(101%);
+}
+
+.btn-close-sm:disabled {
+  opacity: 0.5;
+}
+
 @media (min-width: 992px) {
   .hero__subtitle {
     margin: 0;
@@ -88,10 +87,6 @@ footer {
     width: 14rem;
     height: 14rem;
   }
-
-  .hero-highlight {
-    background-color: rgba(255, 255, 255, 0.9);
-  }
 }
 
 @media (max-width: 575.98px) {
@@ -105,9 +100,5 @@ footer {
 
   .hero__actions-note {
     max-width: none;
-  }
-
-  .hero-highlight {
-    padding: 1.5rem;
   }
 }

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,18 +1,19 @@
 import { useEffect, useMemo, useState } from 'react'
+import { BrowserRouter, Link, Route, Routes } from 'react-router-dom'
 import './App.css'
-import { FilterBar } from './components/FilterBar'
-import { JobCard } from './components/JobCard'
-import { SkillHighlights } from './components/SkillHighlights'
-import { SummaryMetrics } from './components/SummaryMetrics'
+import { HomePage } from './pages/HomePage'
+import { AnalyticsPage } from './pages/AnalyticsPage'
 import { fetchJobs } from './services/jobsService'
 import type { Job, JobFilters } from './types/job'
 import {
+  DATE_POSTED_OPTIONS,
   applyFilters,
   defaultFilters,
-  deriveJobTypeOptions,
   deriveLocationOptions,
+  deriveSearchOptions,
 } from './utils/jobFilters'
 import { buildSkillFrequency } from './utils/skills'
+import { buildCompanyActivity, buildLocationActivity } from './utils/analytics'
 
 function App() {
   const [jobs, setJobs] = useState<Job[]>([])
@@ -51,10 +52,13 @@ function App() {
 
   const filteredJobs = useMemo(() => applyFilters(jobs, filters), [jobs, filters])
   const locationOptions = useMemo(() => deriveLocationOptions(jobs), [jobs])
-  const jobTypeOptions = useMemo(() => deriveJobTypeOptions(jobs), [jobs])
-  const skillFrequency = useMemo(() => buildSkillFrequency(filteredJobs), [filteredJobs])
+  const searchOptions = useMemo(() => deriveSearchOptions(jobs), [jobs])
+  const filteredSkillFrequency = useMemo(() => buildSkillFrequency(filteredJobs), [filteredJobs])
+  const overallSkillFrequency = useMemo(() => buildSkillFrequency(jobs), [jobs])
+  const companyActivity = useMemo(() => buildCompanyActivity(jobs), [jobs])
+  const locationActivity = useMemo(() => buildLocationActivity(jobs, 8), [jobs])
 
-  const metrics = useMemo(
+  const filteredMetrics = useMemo(
     () => ({
       total: filteredJobs.length,
       remote: filteredJobs.filter((job) => job.isRemote === true).length,
@@ -62,6 +66,16 @@ function App() {
       countries: new Set(filteredJobs.map((job) => job.country ?? job.location)).size,
     }),
     [filteredJobs],
+  )
+
+  const overallMetrics = useMemo(
+    () => ({
+      total: jobs.length,
+      remote: jobs.filter((job) => job.isRemote === true).length,
+      companies: new Set(jobs.map((job) => job.company)).size,
+      countries: new Set(jobs.map((job) => job.country ?? job.location)).size,
+    }),
+    [jobs],
   )
 
   const handleFiltersChange = (updates: Partial<JobFilters>) => {
@@ -73,116 +87,65 @@ function App() {
   }
 
   return (
-    <div className="app bg-body-tertiary min-vh-100">
-      <main className="py-4 py-md-5">
-        <div className="container-lg">
-          <header className="hero bg-primary text-white rounded-5 p-4 p-lg-5 mb-5 shadow-sm">
-            <div className="row align-items-center g-4">
-              <div className="col-lg-7 col-xl-6 text-center text-lg-start">
-                <span className="badge bg-white text-primary fw-semibold text-uppercase mb-3">
-                  Middle East · Data Engineering
-                </span>
-                <h1 className="hero__title fw-bold mb-3">
-                  Find your next data engineering role in minutes
-                </h1>
-                <p className="hero__subtitle lead mb-4 text-white-50">
-                  Browse vetted opportunities from Riyadh to Dubai and instantly filter by location, contract type, or
-                  remote-friendly roles.
-                </p>
-                <div className="hero__actions d-flex flex-column flex-sm-row gap-3 align-items-stretch align-items-sm-center">
-                  <a className="btn btn-light btn-lg text-primary fw-semibold shadow-sm" href="#job-results">
-                    Browse open roles
-                  </a>
-                  <div className="hero__actions-note small text-white-50">
-                    <span className="d-block fw-semibold text-white">Focused results</span>
-                    Zero fluff—just the roles and filters you need to plan your next move.
-                  </div>
-                </div>
-              </div>
-              <div className="col-lg-5 col-xl-4 ms-lg-auto">
-                <div className="hero-highlight bg-white text-primary-emphasis rounded-4 shadow-sm p-4">
-                  <h2 className="h5 fw-semibold mb-3">Why professionals use this board</h2>
-                  <ul className="hero-highlight__list list-unstyled mb-0 d-grid gap-2">
-                    <li>
-                      Live metrics summarise total, remote, and company coverage so you can prioritise outreach quickly.
-                    </li>
-                    <li>
-                      Instant keyword search keeps the focus on tools that matter—dbt, Spark, Snowflake, and more.
-                    </li>
-                    <li>Mobile-first layout lets you triage opportunities on the go.</li>
-                  </ul>
-                </div>
-              </div>
-            </div>
-          </header>
-
-          {error && (
-            <div className="alert alert-danger rounded-4 shadow-sm" role="alert">
-              <h2 className="h5">We couldn’t load the latest opportunities</h2>
-              <p className="mb-0">{error}</p>
-            </div>
-          )}
-
-          <SummaryMetrics
-            totalJobs={metrics.total}
-            remoteJobs={metrics.remote}
-            companies={metrics.companies}
-            countries={metrics.countries}
-            isLoading={isLoading}
-          />
-
-          <FilterBar
-            filters={filters}
-            locationOptions={locationOptions}
-            jobTypeOptions={jobTypeOptions}
-            isLoading={isLoading}
-            onChange={handleFiltersChange}
-            onReset={handleReset}
-          />
-
-          <SkillHighlights skills={skillFrequency} />
-
-          <section
-            id="job-results"
-            className="job-results__header d-flex justify-content-between align-items-center mb-3 flex-wrap gap-2"
-          >
-            <h2 className="h4 mb-0">{isLoading ? 'Loading roles…' : `Showing ${filteredJobs.length} roles`}</h2>
-            {!isLoading && jobs.length !== filteredJobs.length && (
-              <span className="badge bg-secondary-subtle text-secondary-emphasis rounded-pill px-3 py-2">
-                Filtered from {jobs.length} total listings
-              </span>
-            )}
-          </section>
-
-          {isLoading && (
-            <div className="text-center py-5">
-              <div className="spinner-border text-primary" role="status" aria-label="Loading jobs" />
-            </div>
-          )}
-
-          {!isLoading && filteredJobs.length === 0 && (
-            <div className="bg-white rounded-4 shadow-sm p-5 text-center">
-              <h3 className="h4 mb-3">No roles match your filters yet</h3>
-              <p className="text-body-secondary mb-0">
-                Try broadening your search, explore another country, or disable the remote-only filter to see more
-                opportunities.
-              </p>
-            </div>
-          )}
-
-          <div className="row row-cols-1 row-cols-lg-2 g-4">
-            {filteredJobs.map((job) => (
-              <div className="col" key={job.id}>
-                <JobCard job={job} />
-              </div>
-            ))}
+    <BrowserRouter>
+      <div className="app bg-body-tertiary min-vh-100 d-flex flex-column">
+        <header className="bg-white border-bottom">
+          <div className="container-lg py-3 d-flex flex-wrap justify-content-between align-items-center gap-3">
+            <Link to="/" className="navbar-brand fs-4 fw-bold text-primary mb-0">
+              ME Data Engineering Jobs
+            </Link>
+            <nav className="d-flex gap-3">
+              <Link to="/" className="btn btn-link text-decoration-none fw-semibold text-primary">
+                Jobs board
+              </Link>
+              <Link to="/analytics" className="btn btn-primary fw-semibold">
+                Analytics dashboard
+              </Link>
+            </nav>
           </div>
-        </div>
-      </main>
-      <footer className="py-4 text-center text-body-secondary small">
-        Built with ❤️ using React, Bootstrap, and Cloudflare Pages · Data source served from Cloudflare R2
-      </footer>
-    </div>
+        </header>
+
+        <Routes>
+          <Route
+            path="/"
+            element={
+              <HomePage
+                jobs={jobs}
+                filteredJobs={filteredJobs}
+                filters={filters}
+                locationOptions={locationOptions}
+                searchOptions={searchOptions}
+                datePostedOptions={DATE_POSTED_OPTIONS}
+                skillFrequency={filteredSkillFrequency}
+                metrics={filteredMetrics}
+                isLoading={isLoading}
+                error={error}
+                onFiltersChange={handleFiltersChange}
+                onResetFilters={handleReset}
+              />
+            }
+          />
+          <Route
+            path="/analytics"
+            element={
+              <AnalyticsPage
+                jobs={jobs}
+                metrics={overallMetrics}
+                companyActivity={companyActivity}
+                locationActivity={locationActivity}
+                skillFrequency={overallSkillFrequency}
+                isLoading={isLoading}
+                error={error}
+              />
+            }
+          />
+        </Routes>
+
+        <footer className="py-4 text-center text-body-secondary small mt-auto">
+          Built with ❤️ using React, Bootstrap, and Cloudflare Pages · Data source served from Cloudflare R2
+        </footer>
+      </div>
+    </BrowserRouter>
   )
 }
 

--- a/web/src/components/FilterBar.tsx
+++ b/web/src/components/FilterBar.tsx
@@ -1,10 +1,12 @@
 import type { ChangeEvent } from 'react'
 import type { JobFilters } from '../types/job'
+import { SearchMultiSelect } from './SearchMultiSelect'
 
 interface FilterBarProps {
   filters: JobFilters
   locationOptions: string[]
-  jobTypeOptions: string[]
+  searchOptions: string[]
+  datePostedOptions: readonly string[]
   isLoading: boolean
   onChange: (updates: Partial<JobFilters>) => void
   onReset: () => void
@@ -21,30 +23,22 @@ const handleTextChange = (
 export const FilterBar = ({
   filters,
   locationOptions,
-  jobTypeOptions,
+  searchOptions,
+  datePostedOptions,
   isLoading,
   onChange,
   onReset,
 }: FilterBarProps) => {
-  const onRemoteToggle = (event: ChangeEvent<HTMLInputElement>) => {
-    onChange({ remoteOnly: event.target.checked })
-  }
-
   return (
     <section className="filter-bar bg-white rounded-4 shadow-sm p-4 mb-4">
       <div className="d-flex flex-column flex-lg-row gap-3 align-items-lg-end">
         <div className="flex-grow-1 w-100">
-          <label htmlFor="searchTerm" className="form-label text-uppercase fw-semibold small text-secondary">
-            Search roles or companies
-          </label>
-          <input
-            id="searchTerm"
-            name="searchTerm"
-            type="search"
-            className="form-control form-control-lg"
+          <SearchMultiSelect
+            label="Search roles or companies"
             placeholder="Search by title, company, technology, or keywords"
-            value={filters.searchTerm}
-            onChange={(event) => handleTextChange(event, onChange)}
+            selected={filters.searchTerms}
+            options={searchOptions}
+            onChange={(next) => onChange({ searchTerms: next })}
             disabled={isLoading}
           />
         </div>
@@ -68,43 +62,23 @@ export const FilterBar = ({
           </select>
         </div>
         <div className="flex-grow-1 w-100">
-          <label htmlFor="jobType" className="form-label text-uppercase fw-semibold small text-secondary">
-            Job type
+          <label htmlFor="datePosted" className="form-label text-uppercase fw-semibold small text-secondary">
+            Date posted
           </label>
           <select
-            id="jobType"
-            name="jobType"
+            id="datePosted"
+            name="datePosted"
             className="form-select form-select-lg"
-            value={filters.jobType}
+            value={filters.datePosted}
             onChange={(event) => handleTextChange(event, onChange)}
             disabled={isLoading}
           >
-            {jobTypeOptions.map((option) => (
+            {datePostedOptions.map((option) => (
               <option key={option} value={option}>
                 {option}
               </option>
             ))}
           </select>
-        </div>
-        <div className="flex-grow-1 w-100">
-          <label className="form-label text-uppercase fw-semibold small text-secondary">
-            Remote friendly
-          </label>
-          <div className="form-check form-switch ps-0 d-flex align-items-center gap-2">
-            <input
-              id="remoteOnly"
-              name="remoteOnly"
-              className="form-check-input ms-0"
-              type="checkbox"
-              role="switch"
-              checked={filters.remoteOnly}
-              onChange={onRemoteToggle}
-              disabled={isLoading}
-            />
-            <label htmlFor="remoteOnly" className="form-check-label fw-semibold">
-              Remote only
-            </label>
-          </div>
         </div>
         <div className="flex-shrink-0">
           <button

--- a/web/src/components/SearchMultiSelect.tsx
+++ b/web/src/components/SearchMultiSelect.tsx
@@ -1,0 +1,133 @@
+import { useId, useMemo, useState } from 'react'
+import type { ChangeEvent, KeyboardEvent } from 'react'
+
+interface SearchMultiSelectProps {
+  label: string
+  placeholder: string
+  selected: string[]
+  options: string[]
+  disabled?: boolean
+  onChange: (next: string[]) => void
+}
+
+const normalise = (value: string) => value.trim().toLowerCase()
+
+export const SearchMultiSelect = ({
+  label,
+  placeholder,
+  selected,
+  options,
+  disabled = false,
+  onChange,
+}: SearchMultiSelectProps) => {
+  const inputId = useId()
+  const listId = `${inputId}-datalist`
+  const [inputValue, setInputValue] = useState('')
+
+  const normalisedSelected = useMemo(() => selected.map(normalise), [selected])
+
+  const addTerm = (value: string) => {
+    const trimmed = value.trim()
+    if (!trimmed) {
+      return
+    }
+
+    const normalisedValue = normalise(trimmed)
+    if (normalisedSelected.includes(normalisedValue)) {
+      setInputValue('')
+      return
+    }
+
+    const matchingOption = options.find((option) => normalise(option) === normalisedValue)
+    const nextValue = matchingOption ?? trimmed
+    onChange([...selected, nextValue])
+    setInputValue('')
+  }
+
+  const removeTerm = (value: string) => {
+    onChange(selected.filter((item) => item !== value))
+  }
+
+  const handleInputChange = (event: ChangeEvent<HTMLInputElement>) => {
+    const { value } = event.target
+    setInputValue(value)
+
+    if (options.some((option) => option === value)) {
+      addTerm(value)
+    }
+  }
+
+  const handleKeyDown = (event: KeyboardEvent<HTMLInputElement>) => {
+    if (event.key === 'Enter' || event.key === 'Tab' || event.key === ',') {
+      if (inputValue.trim().length > 0) {
+        event.preventDefault()
+        addTerm(inputValue)
+      }
+    }
+
+    if (event.key === 'Backspace' && inputValue.length === 0 && selected.length > 0) {
+      event.preventDefault()
+      removeTerm(selected[selected.length - 1])
+    }
+  }
+
+  const handleBlur = () => {
+    if (inputValue.trim().length > 0) {
+      addTerm(inputValue)
+    }
+  }
+
+  const suggestions = useMemo(
+    () =>
+      options
+        .filter((option) => option.toLowerCase().includes(inputValue.trim().toLowerCase()))
+        .filter((option) => !normalisedSelected.includes(normalise(option)))
+        .slice(0, 10),
+    [inputValue, normalisedSelected, options],
+  )
+
+  return (
+    <div>
+      <label htmlFor={inputId} className="form-label text-uppercase fw-semibold small text-secondary">
+        {label}
+      </label>
+      <div className="search-multi-select position-relative">
+        <div className="form-control form-control-lg d-flex flex-wrap gap-2 align-items-center py-2">
+          {selected.map((term) => (
+            <span
+              key={term}
+              className="badge bg-primary-subtle text-primary-emphasis rounded-pill d-flex align-items-center gap-2"
+            >
+              <span>{term}</span>
+              <button
+                type="button"
+                className="btn-close btn-close-sm"
+                aria-label={`Remove ${term}`}
+                onClick={() => removeTerm(term)}
+                disabled={disabled}
+              />
+            </span>
+          ))}
+          <input
+            id={inputId}
+            className="search-multi-select__input flex-grow-1 border-0 bg-transparent"
+            type="search"
+            list={listId}
+            placeholder={selected.length === 0 ? placeholder : ''}
+            value={inputValue}
+            onChange={handleInputChange}
+            onKeyDown={handleKeyDown}
+            onBlur={handleBlur}
+            disabled={disabled}
+            autoComplete="off"
+          />
+        </div>
+        <datalist id={listId}>
+          {suggestions.map((option) => (
+            <option key={option} value={option} />
+          ))}
+        </datalist>
+      </div>
+    </div>
+  )
+}

--- a/web/src/pages/AnalyticsPage.tsx
+++ b/web/src/pages/AnalyticsPage.tsx
@@ -1,0 +1,146 @@
+import { Link } from 'react-router-dom'
+import { SummaryMetrics } from '../components/SummaryMetrics'
+import type { Job } from '../types/job'
+import type { SkillFrequency } from '../utils/skills'
+import type { CompanyActivity, LocationActivity } from '../utils/analytics'
+
+interface AnalyticsPageProps {
+  jobs: Job[]
+  metrics: {
+    total: number
+    remote: number
+    companies: number
+    countries: number
+  }
+  companyActivity: CompanyActivity[]
+  locationActivity: LocationActivity[]
+  skillFrequency: SkillFrequency[]
+  isLoading: boolean
+  error: string | null
+}
+
+export const AnalyticsPage = ({
+  jobs,
+  metrics,
+  companyActivity,
+  locationActivity,
+  skillFrequency,
+  isLoading,
+  error,
+}: AnalyticsPageProps) => (
+  <main className="py-4 py-md-5">
+    <div className="container-lg">
+      <div className="d-flex flex-wrap justify-content-between align-items-center gap-3 mb-4">
+        <div>
+          <h1 className="h2 fw-bold mb-1">Talent market analytics</h1>
+          <p className="text-body-secondary mb-0">
+            A live pulse of data engineering opportunities across the Middle East. Updated automatically from the latest
+            job feed ({jobs.length} listings tracked).
+          </p>
+        </div>
+        <Link to="/" className="btn btn-outline-primary btn-lg fw-semibold">
+          Back to jobs board
+        </Link>
+      </div>
+
+      {error && (
+        <div className="alert alert-danger rounded-4 shadow-sm" role="alert">
+          <h2 className="h5">Analytics are temporarily unavailable</h2>
+          <p className="mb-0">{error}</p>
+        </div>
+      )}
+
+      <section className="bg-white rounded-4 shadow-sm p-4 p-lg-5 mb-4">
+        <div className="d-flex flex-column flex-lg-row justify-content-between gap-3">
+          <div>
+            <h2 className="h4 fw-bold mb-2">General analytics</h2>
+            <p className="text-body-secondary mb-0">
+              Key indicators summarising live opportunities, remote coverage, and cross-country reach.
+            </p>
+          </div>
+          <div className="text-lg-end text-body-secondary small">
+            Last refreshed {isLoading ? '…' : new Intl.DateTimeFormat(undefined, { dateStyle: 'medium', timeStyle: 'short' }).format(new Date())}
+          </div>
+        </div>
+        <SummaryMetrics
+          totalJobs={metrics.total}
+          remoteJobs={metrics.remote}
+          companies={metrics.companies}
+          countries={metrics.countries}
+          isLoading={isLoading}
+        />
+      </section>
+
+      <section className="bg-white rounded-4 shadow-sm p-4 p-lg-5 mb-4">
+        <h2 className="h4 fw-bold mb-3">Most active companies hiring recently</h2>
+        <p className="text-body-secondary mb-4">
+          Ranked by postings published in the last two weeks. Use this shortlist to prioritise outreach.
+        </p>
+        {companyActivity.length === 0 ? (
+          <p className="text-body-secondary mb-0">No recent hiring activity detected.</p>
+        ) : (
+          <ol className="list-group list-group-numbered">
+            {companyActivity.slice(0, 10).map((item) => (
+              <li
+                key={item.company}
+                className="list-group-item d-flex justify-content-between align-items-center border-0 border-bottom py-3"
+              >
+                <span className="fw-semibold">{item.company}</span>
+                <span className="badge bg-primary-subtle text-primary-emphasis rounded-pill px-3 py-2">
+                  {item.count} roles
+                </span>
+              </li>
+            ))}
+          </ol>
+        )}
+      </section>
+
+      <section className="bg-white rounded-4 shadow-sm p-4 p-lg-5 mb-4">
+        <h2 className="h4 fw-bold mb-3">Most in-demand skills</h2>
+        <p className="text-body-secondary mb-4">
+          Aggregated across every live listing. Highlighted skills appear most often in job descriptions.
+        </p>
+        {skillFrequency.length === 0 ? (
+          <p className="text-body-secondary mb-0">No skill data available.</p>
+        ) : (
+          <div className="d-flex flex-wrap gap-2">
+            {skillFrequency.slice(0, 24).map((skill) => (
+              <span
+                key={skill.skill}
+                className="badge bg-secondary-subtle text-secondary-emphasis rounded-pill px-3 py-2"
+              >
+                {skill.skill}
+                <span className="ms-1 text-body-secondary small">({skill.count})</span>
+              </span>
+            ))}
+          </div>
+        )}
+      </section>
+
+      <section className="bg-white rounded-4 shadow-sm p-4 p-lg-5">
+        <h2 className="h4 fw-bold mb-3">Top hiring locations</h2>
+        <p className="text-body-secondary mb-4">
+          Where demand is strongest based on the current dataset. Useful for relocation planning and regional coverage.
+        </p>
+        {locationActivity.length === 0 ? (
+          <p className="text-body-secondary mb-0">No locations available from the current dataset.</p>
+        ) : (
+          <div className="row row-cols-1 row-cols-md-2 g-3">
+            {locationActivity.map((item) => (
+              <div className="col" key={item.location}>
+                <div className="border rounded-4 p-3 h-100 bg-light-subtle">
+                  <div className="d-flex justify-content-between align-items-center">
+                    <span className="fw-semibold">{item.location}</span>
+                    <span className="badge bg-secondary-subtle text-secondary-emphasis rounded-pill px-3 py-2">
+                      {item.count} roles
+                    </span>
+                  </div>
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+      </section>
+    </div>
+  </main>
+)

--- a/web/src/pages/HomePage.tsx
+++ b/web/src/pages/HomePage.tsx
@@ -1,0 +1,135 @@
+import { Link } from 'react-router-dom'
+import { FilterBar } from '../components/FilterBar'
+import { JobCard } from '../components/JobCard'
+import { SkillHighlights } from '../components/SkillHighlights'
+import { SummaryMetrics } from '../components/SummaryMetrics'
+import type { Job, JobFilters } from '../types/job'
+import type { SkillFrequency } from '../utils/skills'
+
+interface HomePageProps {
+  jobs: Job[]
+  filteredJobs: Job[]
+  filters: JobFilters
+  locationOptions: string[]
+  searchOptions: string[]
+  datePostedOptions: readonly string[]
+  skillFrequency: SkillFrequency[]
+  metrics: {
+    total: number
+    remote: number
+    companies: number
+    countries: number
+  }
+  isLoading: boolean
+  error: string | null
+  onFiltersChange: (updates: Partial<JobFilters>) => void
+  onResetFilters: () => void
+}
+
+export const HomePage = ({
+  jobs,
+  filteredJobs,
+  filters,
+  locationOptions,
+  searchOptions,
+  datePostedOptions,
+  skillFrequency,
+  metrics,
+  isLoading,
+  error,
+  onFiltersChange,
+  onResetFilters,
+}: HomePageProps) => (
+  <main className="py-4 py-md-5">
+    <div className="container-lg">
+      <header className="hero bg-primary text-white rounded-5 p-4 p-lg-5 mb-5 shadow-sm">
+        <div className="row align-items-center g-4">
+          <div className="col-lg-9 col-xl-8 text-center text-lg-start mx-lg-auto">
+            <span className="badge bg-white text-primary fw-semibold text-uppercase mb-3">
+              Middle East · Data Engineering
+            </span>
+            <h1 className="hero__title fw-bold mb-3">Find your next data engineering role in minutes</h1>
+            <p className="hero__subtitle lead mb-4 text-white-50">
+              Browse vetted opportunities from Riyadh to Dubai and instantly filter by location or posting date. Build a
+              personalised shortlist using smart keyword combinations.
+            </p>
+            <div className="hero__actions d-flex flex-column flex-sm-row gap-3 align-items-stretch align-items-sm-center">
+              <a className="btn btn-light btn-lg text-primary fw-semibold shadow-sm" href="#job-results">
+                Browse open roles
+              </a>
+              <Link className="btn btn-outline-light btn-lg fw-semibold" to="/analytics">
+                View market analytics
+              </Link>
+              <div className="hero__actions-note small text-white-50 text-start text-sm-center text-lg-start">
+                <span className="d-block fw-semibold text-white">Focused results</span>
+                Multi-select search and posting date filters keep the board tailored to your next move.
+              </div>
+            </div>
+          </div>
+        </div>
+      </header>
+
+      {error && (
+        <div className="alert alert-danger rounded-4 shadow-sm" role="alert">
+          <h2 className="h5">We couldn’t load the latest opportunities</h2>
+          <p className="mb-0">{error}</p>
+        </div>
+      )}
+
+      <SummaryMetrics
+        totalJobs={metrics.total}
+        remoteJobs={metrics.remote}
+        companies={metrics.companies}
+        countries={metrics.countries}
+        isLoading={isLoading}
+      />
+
+      <FilterBar
+        filters={filters}
+        locationOptions={locationOptions}
+        searchOptions={searchOptions}
+        datePostedOptions={datePostedOptions}
+        isLoading={isLoading}
+        onChange={onFiltersChange}
+        onReset={onResetFilters}
+      />
+
+      <SkillHighlights skills={skillFrequency} />
+
+      <section
+        id="job-results"
+        className="job-results__header d-flex justify-content-between align-items-center mb-3 flex-wrap gap-2"
+      >
+        <h2 className="h4 mb-0">{isLoading ? 'Loading roles…' : `Showing ${filteredJobs.length} roles`}</h2>
+        {!isLoading && jobs.length !== filteredJobs.length && (
+          <span className="badge bg-secondary-subtle text-secondary-emphasis rounded-pill px-3 py-2">
+            Filtered from {jobs.length} total listings
+          </span>
+        )}
+      </section>
+
+      {isLoading && (
+        <div className="text-center py-5">
+          <div className="spinner-border text-primary" role="status" aria-label="Loading jobs" />
+        </div>
+      )}
+
+      {!isLoading && filteredJobs.length === 0 && (
+        <div className="bg-white rounded-4 shadow-sm p-5 text-center">
+          <h3 className="h4 mb-3">No roles match your filters yet</h3>
+          <p className="text-body-secondary mb-0">
+            Try broadening your search, explore another country, or adjust the posting date filter to see more opportunities.
+          </p>
+        </div>
+      )}
+
+      <div className="row row-cols-1 row-cols-lg-2 g-4">
+        {filteredJobs.map((job) => (
+          <div className="col" key={job.id}>
+            <JobCard job={job} />
+          </div>
+        ))}
+      </div>
+    </div>
+  </main>
+)

--- a/web/src/types/job.ts
+++ b/web/src/types/job.ts
@@ -27,8 +27,7 @@ export interface Job {
 }
 
 export interface JobFilters {
-  searchTerm: string
+  searchTerms: string[]
   location: string
-  jobType: string
-  remoteOnly: boolean
+  datePosted: string
 }

--- a/web/src/utils/analytics.ts
+++ b/web/src/utils/analytics.ts
@@ -1,0 +1,66 @@
+import type { Job } from '../types/job'
+
+export interface CompanyActivity {
+  company: string
+  count: number
+}
+
+export interface LocationActivity {
+  location: string
+  count: number
+}
+
+const isWithinWindow = (job: Job, days: number): boolean => {
+  if (!job.postingDate) {
+    return false
+  }
+
+  const postingDate = new Date(job.postingDate)
+  if (Number.isNaN(postingDate.getTime())) {
+    return false
+  }
+
+  const now = new Date()
+  const threshold = new Date(now.getTime() - days * 24 * 60 * 60 * 1000)
+  return postingDate >= threshold
+}
+
+export const buildCompanyActivity = (jobs: Job[], days = 14): CompanyActivity[] => {
+  const counts = new Map<string, number>()
+
+  jobs.forEach((job) => {
+    if (!job.company) {
+      return
+    }
+
+    if (!isWithinWindow(job, days)) {
+      return
+    }
+
+    const current = counts.get(job.company) ?? 0
+    counts.set(job.company, current + 1)
+  })
+
+  return Array.from(counts.entries())
+    .map(([company, count]) => ({ company, count }))
+    .sort((a, b) => b.count - a.count || a.company.localeCompare(b.company))
+}
+
+export const buildLocationActivity = (jobs: Job[], limit = 5): LocationActivity[] => {
+  const counts = new Map<string, number>()
+
+  jobs.forEach((job) => {
+    const label = job.country ?? job.location
+    if (!label) {
+      return
+    }
+
+    const current = counts.get(label) ?? 0
+    counts.set(label, current + 1)
+  })
+
+  return Array.from(counts.entries())
+    .map(([location, count]) => ({ location, count }))
+    .sort((a, b) => b.count - a.count || a.location.localeCompare(b.location))
+    .slice(0, limit)
+}


### PR DESCRIPTION
## Summary
- replace the landing hero sidebar with a streamlined call to action and add navigation for a new analytics dashboard
- introduce a multi-select autocomplete search bar with posting-date filters while retiring job-type and remote toggles
- build a dedicated analytics page summarising market metrics, active companies, top skills, and hiring locations
- expand unit and integration tests plus documentation to cover the new filtering and analytics experiences

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68e553f2dbec8332a5b79190ec764b3f