### PR TITLE
Enhance analytics dashboard and add custom analytics workspace

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,14 +2,19 @@
 
 This repository hosts a modern single-page application that spotlights data engineering opportunities across the Middle
 East. The site is designed to run as a static Cloudflare Pages deployment while sourcing live job listings from a JSON
-object stored in Cloudflare R2. The landing experience is streamlined for actionable content, introduces an analytics
-dashboard with hiring trends, and adapts fluidly to mobile screens so job seekers can triage roles on the go.
+object stored in Cloudflare R2. The landing experience is now intentionally information-dense, the analytics suite
+includes trend charts, salary benchmarks, and geographic breakdowns, and users can assemble bespoke dashboards through a
+self-service workspace.
 
 ## Highlights
 
 - 🔍 Multi-select keyword search with autocomplete suggestions spanning job titles, companies, and in-demand skills.
 - 🗓️ Posting date filters (24 hours, 3 days, 1 week, 2 weeks) to surface the freshest opportunities instantly.
-- 📊 Dedicated analytics page summarising market metrics, recent hiring companies, and skills momentum.
+- 📊 Dedicated analytics page with hiring velocity, remote adoption, salary benchmarks, industry momentum, and skills
+  demand visualisations powered by bespoke SVG charts.
+- 🧩 Custom analytics workspace where power users can combine grouping dimensions (company, country, skills, remote
+  status, etc.) with bar, donut, or table widgets to answer ad-hoc questions.
+- 🧪 Automated unit + integration test coverage that validates data ingest, UI flows, and analytics aggregations.
 
 ## Project structure
 
@@ -40,7 +45,7 @@ dashboard with hiring trends, and adapts fluidly to mobile screens so job seeker
    npm run dev
    ```
 
-4. Execute the automated test suite (unit + integration):
+4. Execute the automated test suite (unit + integration + analytics helpers):
 
    ```bash
    npm test

--- a/web/README.md
+++ b/web/README.md
@@ -5,13 +5,18 @@ across the Middle East by reading a JSON feed stored in Cloudflare R2.
 
 ## Features
 
-- 🎯 **Focused experience** – Highlights data engineering roles with company, location, and posting insights.
+- 🎯 **Focused experience** – Condensed landing page with immediate access to filters, summary metrics, and job results.
 - 📱 **Mobile-first design** – Responsive layout keeps the filters and results easy to read on phones and tablets.
 - 🔍 **Powerful filters** – Multi-select keyword search with autocomplete, country filtering, and posting date controls.
-- 📊 **Market signals** – Dedicated analytics dashboard with hiring momentum, cross-country coverage, and in-demand technologies.
+- 📈 **Advanced analytics** – Hiring velocity sparkline, remote adoption donut, salary benchmarks, industry momentum, and
+  location coverage tables – all rendered with lightweight SVG charts.
+- 🧩 **Custom analytics workspace** – Compose bespoke bar, donut, or table widgets by grouping the live dataset across
+  companies, geographies, skills, remote status, and more.
 - ☁️ **Cloudflare ready** – Designed for static deployment with data delivered from R2 via `VITE_JOBS_DATA_URL`.
-- ✅ **Quality assured** – Includes unit and integration tests powered by Vitest and Testing Library.
-- 🛡️ **Resilient data ingest** – Normalises Cloudflare R2 payloads and defends against network failures with tested fallbacks.
+- ✅ **Quality assured** – Includes unit, integration, and analytics aggregation tests powered by Vitest and Testing
+  Library.
+- 🛡️ **Resilient data ingest** – Normalises Cloudflare R2 payloads and defends against network failures with tested
+  fallbacks.
 
 ## Getting started locally
 
@@ -53,7 +58,7 @@ the user for this exercise is `https://6d9a56e137a3328cc52e48656dd30d91.r2.cloud
 
 ## Testing strategy
 
-- **Unit tests** cover the filtering logic to guarantee consistent search and filter behaviour.
+- **Unit tests** cover the filtering logic and analytics aggregations to guarantee consistent insights.
 - **Integration tests** render the full application, mock the R2 fetch call, and validate that user flows (search and
   posting-date filtering) operate end-to-end.
 

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -3,6 +3,7 @@ import { BrowserRouter, Link, Route, Routes } from 'react-router-dom'
 import './App.css'
 import { HomePage } from './pages/HomePage'
 import { AnalyticsPage } from './pages/AnalyticsPage'
+import { CustomAnalyticsPage } from './pages/CustomAnalyticsPage'
 import { fetchJobs } from './services/jobsService'
 import type { Job, JobFilters } from './types/job'
 import {
@@ -13,7 +14,15 @@ import {
   deriveSearchOptions,
 } from './utils/jobFilters'
 import { buildSkillFrequency } from './utils/skills'
-import { buildCompanyActivity, buildLocationActivity } from './utils/analytics'
+import {
+  buildCompanyActivity,
+  buildIndustryBreakdown,
+  buildLocationActivity,
+  buildLocationRemoteStats,
+  buildPostingTrends,
+  buildRemoteSplit,
+  buildSalaryBenchmarks,
+} from './utils/analytics'
 
 function App() {
   const [jobs, setJobs] = useState<Job[]>([])
@@ -57,6 +66,11 @@ function App() {
   const overallSkillFrequency = useMemo(() => buildSkillFrequency(jobs), [jobs])
   const companyActivity = useMemo(() => buildCompanyActivity(jobs), [jobs])
   const locationActivity = useMemo(() => buildLocationActivity(jobs, 8), [jobs])
+  const postingTrends = useMemo(() => buildPostingTrends(jobs, 12), [jobs])
+  const remoteSplit = useMemo(() => buildRemoteSplit(jobs), [jobs])
+  const salaryBenchmarks = useMemo(() => buildSalaryBenchmarks(jobs), [jobs])
+  const industryBreakdown = useMemo(() => buildIndustryBreakdown(jobs), [jobs])
+  const locationRemoteStats = useMemo(() => buildLocationRemoteStats(jobs, 10), [jobs])
 
   const filteredMetrics = useMemo(
     () => ({
@@ -94,12 +108,15 @@ function App() {
             <Link to="/" className="navbar-brand fs-4 fw-bold text-primary mb-0">
               ME Data Engineering Jobs
             </Link>
-            <nav className="d-flex gap-3">
+            <nav className="d-flex flex-wrap gap-2">
               <Link to="/" className="btn btn-link text-decoration-none fw-semibold text-primary">
                 Jobs board
               </Link>
-              <Link to="/analytics" className="btn btn-primary fw-semibold">
+              <Link to="/analytics" className="btn btn-outline-primary fw-semibold">
                 Analytics dashboard
+              </Link>
+              <Link to="/custom-analytics" className="btn btn-primary fw-semibold">
+                Custom analytics
               </Link>
             </nav>
           </div>
@@ -133,11 +150,20 @@ function App() {
                 metrics={overallMetrics}
                 companyActivity={companyActivity}
                 locationActivity={locationActivity}
+                locationRemoteStats={locationRemoteStats}
+                industryBreakdown={industryBreakdown}
+                salaryBenchmarks={salaryBenchmarks}
+                remoteSplit={remoteSplit}
+                postingTrends={postingTrends}
                 skillFrequency={overallSkillFrequency}
                 isLoading={isLoading}
                 error={error}
               />
             }
+          />
+          <Route
+            path="/custom-analytics"
+            element={<CustomAnalyticsPage jobs={jobs} isLoading={isLoading} error={error} />}
           />
         </Routes>
 

--- a/web/src/__tests__/App.integration.test.tsx
+++ b/web/src/__tests__/App.integration.test.tsx
@@ -57,7 +57,7 @@ describe('App integration', () => {
     render(<App />)
 
     await waitFor(() => {
-      expect(screen.getByRole('alert')).toHaveTextContent('Unable to load jobs data')
+      expect(screen.getByRole('alert')).toHaveTextContent('We couldn’t load the latest opportunities')
       expect(screen.getByRole('alert')).toHaveTextContent('Network unavailable')
     })
   })

--- a/web/src/__tests__/App.test.tsx
+++ b/web/src/__tests__/App.test.tsx
@@ -38,12 +38,15 @@ describe('App', () => {
     mockJobsPayload[0].date_posted = now.toISOString()
     mockJobsPayload[1].date_posted = new Date(now.getTime() - 7 * 24 * 60 * 60 * 1000).toISOString()
     vi.stubEnv('VITE_JOBS_DATA_URL', 'https://example.com/jobs.json')
-    vi.stubGlobal('fetch', vi.fn(() =>
-      Promise.resolve({
-        ok: true,
-        json: () => Promise.resolve(mockJobsPayload),
-      }) as unknown as Response,
-    ))
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(() =>
+        Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve(mockJobsPayload),
+        }) as unknown as Response,
+      ),
+    )
   })
 
   afterEach(() => {
@@ -51,20 +54,12 @@ describe('App', () => {
     vi.restoreAllMocks()
   })
 
-  it('shows a focused hero message with a call to action', async () => {
+  it('presents a dense overview with quick access to analytics and results', async () => {
     render(<App />)
 
-    expect(
-      await screen.findByRole('link', {
-        name: /browse open roles/i,
-      }),
-    ).toHaveAttribute('href', '#job-results')
-
-    expect(await screen.findByRole('link', { name: /view market analytics/i })).toHaveAttribute(
-      'href',
-      '/analytics',
-    )
-    expect(await screen.findByText(/multi-select search and posting date filters/i)).toBeInTheDocument()
+    expect(await screen.findByRole('link', { name: /jump to results/i })).toHaveAttribute('href', '#job-results')
+    expect(await screen.findByRole('link', { name: /view analytics/i })).toHaveAttribute('href', '/analytics')
+    expect(screen.getByRole('link', { name: /custom analytics/i })).toHaveAttribute('href', '/custom-analytics')
   })
 
   it('renders job cards after fetching data', async () => {

--- a/web/src/__tests__/analytics.test.ts
+++ b/web/src/__tests__/analytics.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it } from 'vitest'
+import type { Job } from '../types/job'
+import {
+  buildIndustryBreakdown,
+  buildLocationRemoteStats,
+  buildPostingTrends,
+  buildRemoteSplit,
+  buildSalaryBenchmarks,
+} from '../utils/analytics'
+
+const baseJob: Job = {
+  id: '1',
+  title: 'Data Engineer',
+  company: 'Acme',
+  location: 'Riyadh, Saudi Arabia',
+  country: 'Saudi Arabia',
+  jobType: 'Full-time',
+  postingDate: '2025-01-06T00:00:00.000Z',
+  source: 'LinkedIn',
+  jobUrl: null,
+  minSalary: null,
+  maxSalary: null,
+  currency: null,
+  isRemote: null,
+  techSkills: [],
+  softSkills: [],
+  domainSkills: [],
+  raw: {},
+}
+
+describe('analytics helpers', () => {
+  it('builds posting trends grouped by week with remote counts', () => {
+    const jobs: Job[] = [
+      { ...baseJob, id: '1', postingDate: '2025-01-01T00:00:00Z', isRemote: true },
+      { ...baseJob, id: '2', postingDate: '2025-01-03T00:00:00Z', isRemote: false },
+      { ...baseJob, id: '3', postingDate: '2025-01-10T00:00:00Z', isRemote: true },
+      { ...baseJob, id: '4', postingDate: '2025-01-11T00:00:00Z', isRemote: null },
+    ]
+
+    const trends = buildPostingTrends(jobs, 4)
+    expect(trends).toHaveLength(2)
+    expect(trends[0].total).toBe(2)
+    expect(trends[0].remote).toBe(1)
+    expect(trends[1].total).toBe(2)
+    expect(trends[1].remote).toBe(1)
+  })
+
+  it('calculates remote split across remote, on-site and unspecified roles', () => {
+    const jobs: Job[] = [
+      { ...baseJob, id: '1', isRemote: true },
+      { ...baseJob, id: '2', isRemote: false },
+      { ...baseJob, id: '3', isRemote: null },
+    ]
+
+    const split = buildRemoteSplit(jobs)
+    expect(split).toEqual([
+      { label: 'Remote', count: 1 },
+      { label: 'On-site', count: 1 },
+      { label: 'Unspecified', count: 1 },
+    ])
+  })
+
+  it('produces salary benchmarks grouped by currency', () => {
+    const jobs: Job[] = [
+      { ...baseJob, id: '1', currency: 'USD', minSalary: 90000, maxSalary: 110000 },
+      { ...baseJob, id: '2', currency: 'USD', minSalary: 95000, maxSalary: 120000 },
+      { ...baseJob, id: '3', currency: 'AED', minSalary: 300000, maxSalary: 360000 },
+    ]
+
+    const benchmarks = buildSalaryBenchmarks(jobs)
+    expect(benchmarks).toHaveLength(2)
+    const usd = benchmarks.find((item) => item.currency === 'USD')
+    expect(usd).toBeDefined()
+    expect(usd?.roles).toBe(2)
+    expect(Math.round(usd?.average ?? 0)).toBe(103750)
+    expect(usd?.minimum).toBe(90000)
+    expect(usd?.maximum).toBe(120000)
+  })
+
+  it('summarises industry breakdown with remote share', () => {
+    const jobs: Job[] = [
+      { ...baseJob, id: '1', industry: 'Energy', isRemote: true },
+      { ...baseJob, id: '2', industry: 'Energy', isRemote: false },
+      { ...baseJob, id: '3', industry: 'Finance', isRemote: false },
+    ]
+
+    const breakdown = buildIndustryBreakdown(jobs)
+    const energy = breakdown.find((item) => item.industry === 'Energy')
+    expect(energy).toBeDefined()
+    expect(energy?.roles).toBe(2)
+    expect(energy?.remoteShare).toBeCloseTo(0.5)
+  })
+
+  it('calculates location remote stats with remote share percentages', () => {
+    const jobs: Job[] = [
+      { ...baseJob, id: '1', location: 'Dubai, UAE', country: 'United Arab Emirates', isRemote: true },
+      { ...baseJob, id: '2', location: 'Dubai, UAE', country: 'United Arab Emirates', isRemote: false },
+      { ...baseJob, id: '3', location: 'Dubai, UAE', country: 'United Arab Emirates', isRemote: null },
+      { ...baseJob, id: '4', location: 'Riyadh, Saudi Arabia', country: 'Saudi Arabia', isRemote: false },
+    ]
+
+    const stats = buildLocationRemoteStats(jobs)
+    const dubai = stats.find((item) => item.location === 'United Arab Emirates')
+    expect(dubai).toBeDefined()
+    expect(dubai?.total).toBe(3)
+    expect(dubai?.remote).toBe(1)
+    expect(dubai?.onsite).toBe(1)
+    expect(dubai?.unknown).toBe(1)
+    expect(dubai?.remoteShare).toBeCloseTo(1 / 3)
+  })
+})

--- a/web/src/components/charts/BarChart.tsx
+++ b/web/src/components/charts/BarChart.tsx
@@ -1,0 +1,80 @@
+export interface BarChartDatum {
+  label: string
+  value: number
+  secondaryValue?: number
+}
+
+interface BarChartProps {
+  data: BarChartDatum[]
+  maxValue?: number
+  showValues?: boolean
+  ariaLabel?: string
+  condensed?: boolean
+}
+
+const formatNumber = (value: number): string => {
+  if (value >= 1_000_000) {
+    return `${(value / 1_000_000).toFixed(1)}M`
+  }
+  if (value >= 1_000) {
+    return `${(value / 1_000).toFixed(1)}k`
+  }
+  return value.toString()
+}
+
+export const BarChart = ({ data, maxValue, showValues = true, ariaLabel, condensed = false }: BarChartProps) => {
+  if (data.length === 0) {
+    return <p className="text-body-secondary mb-0">No data available.</p>
+  }
+
+  const resolvedMaxValue =
+    maxValue ??
+    data.reduce((acc, item) => {
+      const candidate = item.secondaryValue ? Math.max(item.value, item.secondaryValue) : item.value
+      return Math.max(acc, candidate)
+    }, 0)
+
+  const containerClass = `d-flex flex-column ${condensed ? 'gap-2' : 'gap-3'}`
+
+  return (
+    <div className={containerClass} role={ariaLabel ? 'list' : undefined} aria-label={ariaLabel}>
+      {data.map((item) => {
+        const valuePercentage = resolvedMaxValue > 0 ? Math.round((item.value / resolvedMaxValue) * 100) : 0
+        const secondaryPercentage =
+          item.secondaryValue !== undefined && resolvedMaxValue > 0
+            ? Math.round((item.secondaryValue / resolvedMaxValue) * 100)
+            : undefined
+
+        return (
+          <div key={item.label} role={ariaLabel ? 'listitem' : undefined}>
+            <div className={`d-flex align-items-baseline justify-content-between ${condensed ? 'mb-1' : ''}`}>
+              <span className="fw-semibold text-truncate me-3" title={item.label}>
+                {item.label}
+              </span>
+              {showValues && (
+                <span className="text-body-secondary small">
+                  {formatNumber(item.value)}
+                  {item.secondaryValue !== undefined && ` · ${formatNumber(item.secondaryValue)}`}
+                </span>
+              )}
+            </div>
+            <div className="position-relative bg-body-secondary bg-opacity-50 rounded-pill" style={{ height: condensed ? '0.5rem' : '0.75rem' }}>
+              <div
+                className="bg-primary rounded-pill"
+                style={{ width: `${valuePercentage}%`, height: '100%', transition: 'width 0.3s ease' }}
+                aria-hidden
+              />
+              {secondaryPercentage !== undefined && (
+                <div
+                  className="bg-success bg-opacity-75 rounded-pill position-absolute top-0"
+                  style={{ width: `${secondaryPercentage}%`, height: '100%', transition: 'width 0.3s ease' }}
+                  aria-hidden
+                />
+              )}
+            </div>
+          </div>
+        )
+      })}
+    </div>
+  )
+}

--- a/web/src/components/charts/DonutChart.tsx
+++ b/web/src/components/charts/DonutChart.tsx
@@ -1,0 +1,85 @@
+export interface DonutChartSegment {
+  label: string
+  value: number
+  color?: string
+}
+
+interface DonutChartProps {
+  segments: DonutChartSegment[]
+  size?: number
+  strokeWidth?: number
+  showLegend?: boolean
+  ariaLabel?: string
+}
+
+const defaultPalette = ['#0d6efd', '#20c997', '#ffc107', '#6610f2', '#fd7e14', '#6f42c1', '#dc3545']
+
+export const DonutChart = ({
+  segments,
+  size = 160,
+  strokeWidth = 22,
+  showLegend = true,
+  ariaLabel,
+}: DonutChartProps) => {
+  const total = segments.reduce((acc, item) => acc + item.value, 0)
+
+  if (total === 0) {
+    return <p className="text-body-secondary mb-0">No data available.</p>
+  }
+
+  const radius = (size - strokeWidth) / 2
+  const circumference = 2 * Math.PI * radius
+  let cumulativeOffset = 0
+
+  return (
+    <div className="d-flex flex-column flex-lg-row align-items-center gap-3" aria-label={ariaLabel}>
+      <svg width={size} height={size} role="img" aria-hidden={!ariaLabel}>
+        <title>{ariaLabel}</title>
+        <g transform={`translate(${size / 2}, ${size / 2}) rotate(-90)`}>
+          {segments.map((segment, index) => {
+            const value = segment.value
+            const normalizedValue = value / total
+            const dashArray = normalizedValue * circumference
+            const dashOffset = circumference - cumulativeOffset
+            cumulativeOffset += dashArray
+
+            return (
+              <circle
+                key={segment.label}
+                r={radius}
+                fill="transparent"
+                stroke={segment.color ?? defaultPalette[index % defaultPalette.length]}
+                strokeWidth={strokeWidth}
+                strokeDasharray={`${dashArray} ${circumference}`}
+                strokeDashoffset={dashOffset}
+              />
+            )
+          })}
+        </g>
+      </svg>
+      {showLegend && (
+        <div className="d-flex flex-column gap-2 w-100">
+          {segments.map((segment, index) => {
+            const percentage = ((segment.value / total) * 100).toFixed(1)
+            const color = segment.color ?? defaultPalette[index % defaultPalette.length]
+            return (
+              <div key={segment.label} className="d-flex align-items-center justify-content-between gap-2">
+                <div className="d-flex align-items-center gap-2">
+                  <span
+                    className="rounded-2 d-inline-block"
+                    style={{ width: '0.75rem', height: '0.75rem', backgroundColor: color }}
+                    aria-hidden
+                  />
+                  <span className="fw-semibold text-truncate" title={segment.label}>
+                    {segment.label}
+                  </span>
+                </div>
+                <span className="text-body-secondary small">{percentage}%</span>
+              </div>
+            )
+          })}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/web/src/components/charts/SparklineChart.tsx
+++ b/web/src/components/charts/SparklineChart.tsx
@@ -1,0 +1,46 @@
+export interface SparklineDatum {
+  label: string
+  value: number
+}
+
+interface SparklineChartProps {
+  data: SparklineDatum[]
+  height?: number
+  strokeColor?: string
+  ariaLabel?: string
+}
+
+export const SparklineChart = ({ data, height = 64, strokeColor = '#0d6efd', ariaLabel }: SparklineChartProps) => {
+  if (data.length === 0) {
+    return <p className="text-body-secondary mb-0">No data available.</p>
+  }
+
+  const width = data.length * 36
+  const values = data.map((item) => item.value)
+  const min = Math.min(...values)
+  const max = Math.max(...values)
+  const range = max - min || 1
+
+  const points = data
+    .map((item, index) => {
+      const x = (index / (data.length - 1 || 1)) * width
+      const y = height - ((item.value - min) / range) * height
+      return `${x},${y}`
+    })
+    .join(' ')
+
+  return (
+    <figure className="mb-0" aria-label={ariaLabel}>
+      <svg width="100%" viewBox={`0 0 ${width} ${height}`} role="img" aria-hidden={!ariaLabel}>
+        <title>{ariaLabel}</title>
+        <polyline points={points} fill="none" stroke={strokeColor} strokeWidth="3" strokeLinecap="round" />
+        {data.map((item, index) => {
+          const x = (index / (data.length - 1 || 1)) * width
+          const y = height - ((item.value - min) / range) * height
+          return <circle key={item.label} cx={x} cy={y} r="4" fill={strokeColor} />
+        })}
+      </svg>
+      <figcaption className="visually-hidden">{data.map((item) => `${item.label}: ${item.value}`).join(', ')}</figcaption>
+    </figure>
+  )
+}

--- a/web/src/pages/AnalyticsPage.tsx
+++ b/web/src/pages/AnalyticsPage.tsx
@@ -1,8 +1,19 @@
 import { Link } from 'react-router-dom'
 import { SummaryMetrics } from '../components/SummaryMetrics'
+import { BarChart } from '../components/charts/BarChart'
+import { DonutChart } from '../components/charts/DonutChart'
+import { SparklineChart } from '../components/charts/SparklineChart'
 import type { Job } from '../types/job'
 import type { SkillFrequency } from '../utils/skills'
-import type { CompanyActivity, LocationActivity } from '../utils/analytics'
+import type {
+  CompanyActivity,
+  IndustryBreakdown,
+  LocationActivity,
+  LocationRemoteStat,
+  RemoteSplitSegment,
+  SalaryBenchmark,
+  WeeklyTrendPoint,
+} from '../utils/analytics'
 
 interface AnalyticsPageProps {
   jobs: Job[]
@@ -14,9 +25,25 @@ interface AnalyticsPageProps {
   }
   companyActivity: CompanyActivity[]
   locationActivity: LocationActivity[]
+  locationRemoteStats: LocationRemoteStat[]
+  industryBreakdown: IndustryBreakdown[]
+  salaryBenchmarks: SalaryBenchmark[]
+  remoteSplit: RemoteSplitSegment[]
+  postingTrends: WeeklyTrendPoint[]
   skillFrequency: SkillFrequency[]
   isLoading: boolean
   error: string | null
+}
+
+const formatSalary = (value: number, currency: string): string => {
+  if (!Number.isFinite(value) || value <= 0) {
+    return '—'
+  }
+  try {
+    return new Intl.NumberFormat(undefined, { style: 'currency', currency, maximumFractionDigits: 0 }).format(value)
+  } catch (error) {
+    return `${currency} ${value.toLocaleString()}`
+  }
 }
 
 export const AnalyticsPage = ({
@@ -24,6 +51,11 @@ export const AnalyticsPage = ({
   metrics,
   companyActivity,
   locationActivity,
+  locationRemoteStats,
+  industryBreakdown,
+  salaryBenchmarks,
+  remoteSplit,
+  postingTrends,
   skillFrequency,
   isLoading,
   error,
@@ -34,13 +66,16 @@ export const AnalyticsPage = ({
         <div>
           <h1 className="h2 fw-bold mb-1">Talent market analytics</h1>
           <p className="text-body-secondary mb-0">
-            A live pulse of data engineering opportunities across the Middle East. Updated automatically from the latest
-            job feed ({jobs.length} listings tracked).
+            {isLoading
+              ? 'Refreshing insights from the latest roles feed…'
+              : `${jobs.length} listings processed. Review velocity, remote adoption, salary benchmarks and geographic coverage.`}
           </p>
         </div>
-        <Link to="/" className="btn btn-outline-primary btn-lg fw-semibold">
-          Back to jobs board
-        </Link>
+        <div className="d-flex flex-wrap gap-2">
+          <Link to="/" className="btn btn-outline-primary fw-semibold">
+            Back to jobs board
+          </Link>
+        </div>
       </div>
 
       {error && (
@@ -53,9 +88,9 @@ export const AnalyticsPage = ({
       <section className="bg-white rounded-4 shadow-sm p-4 p-lg-5 mb-4">
         <div className="d-flex flex-column flex-lg-row justify-content-between gap-3">
           <div>
-            <h2 className="h4 fw-bold mb-2">General analytics</h2>
+            <h2 className="h4 fw-bold mb-2">Market snapshot</h2>
             <p className="text-body-secondary mb-0">
-              Key indicators summarising live opportunities, remote coverage, and cross-country reach.
+              Totals across the active dataset. Trends auto-refresh whenever the data feed updates.
             </p>
           </div>
           <div className="text-lg-end text-body-secondary small">
@@ -71,29 +106,190 @@ export const AnalyticsPage = ({
         />
       </section>
 
-      <section className="bg-white rounded-4 shadow-sm p-4 p-lg-5 mb-4">
-        <h2 className="h4 fw-bold mb-3">Most active companies hiring recently</h2>
-        <p className="text-body-secondary mb-4">
-          Ranked by postings published in the last two weeks. Use this shortlist to prioritise outreach.
-        </p>
-        {companyActivity.length === 0 ? (
-          <p className="text-body-secondary mb-0">No recent hiring activity detected.</p>
-        ) : (
-          <ol className="list-group list-group-numbered">
-            {companyActivity.slice(0, 10).map((item) => (
-              <li
-                key={item.company}
-                className="list-group-item d-flex justify-content-between align-items-center border-0 border-bottom py-3"
-              >
-                <span className="fw-semibold">{item.company}</span>
-                <span className="badge bg-primary-subtle text-primary-emphasis rounded-pill px-3 py-2">
-                  {item.count} roles
-                </span>
-              </li>
-            ))}
-          </ol>
-        )}
-      </section>
+      <div className="row g-4 mb-4">
+        <div className="col-12 col-lg-6">
+          <section className="bg-white rounded-4 shadow-sm p-4 h-100">
+            <div className="d-flex justify-content-between align-items-start mb-3">
+              <div>
+                <h2 className="h5 fw-bold mb-1">Hiring velocity</h2>
+                <p className="text-body-secondary small mb-0">
+                  Weekly postings for the past quarter with remote contributions highlighted.
+                </p>
+              </div>
+              <span className="badge bg-primary-subtle text-primary-emphasis">{postingTrends.length} weeks</span>
+            </div>
+            <SparklineChart
+              data={postingTrends.map((point) => ({ label: point.label, value: point.total }))}
+              ariaLabel="Weekly job posting trend"
+            />
+            <div className="mt-3">
+              <BarChart
+                data={postingTrends
+                  .slice(-5)
+                  .map((point) => ({ label: point.label, value: point.total, secondaryValue: point.remote }))}
+                condensed
+                showValues
+                ariaLabel="Remote versus total postings for recent weeks"
+              />
+            </div>
+          </section>
+        </div>
+        <div className="col-12 col-lg-6">
+          <section className="bg-white rounded-4 shadow-sm p-4 h-100">
+            <div className="d-flex justify-content-between align-items-start mb-3">
+              <div>
+                <h2 className="h5 fw-bold mb-1">Remote adoption</h2>
+                <p className="text-body-secondary small mb-0">
+                  Share of listings marked as remote, on-site, or unspecified.
+                </p>
+              </div>
+            </div>
+            <DonutChart segments={remoteSplit.map((segment) => ({ label: segment.label, value: segment.count }))} ariaLabel="Remote adoption split" />
+          </section>
+        </div>
+      </div>
+
+      <div className="row g-4 mb-4">
+        <div className="col-12 col-xl-6">
+          <section className="bg-white rounded-4 shadow-sm p-4 h-100">
+            <div className="d-flex justify-content-between align-items-start mb-3">
+              <div>
+                <h2 className="h5 fw-bold mb-1">Salary benchmarks by currency</h2>
+                <p className="text-body-secondary small mb-0">
+                  Midpoint averages based on roles that disclose salary ranges.
+                </p>
+              </div>
+            </div>
+            {salaryBenchmarks.length === 0 ? (
+              <p className="text-body-secondary mb-0">No salary data available from the current dataset.</p>
+            ) : (
+              <div className="table-responsive">
+                <table className="table table-sm align-middle mb-0">
+                  <thead>
+                    <tr>
+                      <th scope="col">Currency</th>
+                      <th scope="col" className="text-end">
+                        Roles
+                      </th>
+                      <th scope="col" className="text-end">
+                        Avg midpoint
+                      </th>
+                      <th scope="col" className="text-end">
+                        Range
+                      </th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {salaryBenchmarks.map((benchmark) => (
+                      <tr key={benchmark.currency}>
+                        <th scope="row">{benchmark.currency}</th>
+                        <td className="text-end">{benchmark.roles}</td>
+                        <td className="text-end">{formatSalary(Math.round(benchmark.average), benchmark.currency)}</td>
+                        <td className="text-end">
+                          {formatSalary(benchmark.minimum, benchmark.currency)} –{' '}
+                          {formatSalary(benchmark.maximum, benchmark.currency)}
+                        </td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            )}
+          </section>
+        </div>
+        <div className="col-12 col-xl-6">
+          <section className="bg-white rounded-4 shadow-sm p-4 h-100">
+            <div className="d-flex justify-content-between align-items-start mb-3">
+              <div>
+                <h2 className="h5 fw-bold mb-1">Industry momentum</h2>
+                <p className="text-body-secondary small mb-0">
+                  Top sectors currently investing in data engineering talent and their remote share.
+                </p>
+              </div>
+            </div>
+            <BarChart
+              data={industryBreakdown.map((item) => ({
+                label: item.industry,
+                value: item.roles,
+                secondaryValue: Math.round(item.remoteShare * item.roles),
+              }))}
+              ariaLabel="Industry hiring volume with remote roles highlighted"
+            />
+          </section>
+        </div>
+      </div>
+
+      <div className="row g-4 mb-4">
+        <div className="col-12 col-xl-6">
+          <section className="bg-white rounded-4 shadow-sm p-4 h-100">
+            <div className="d-flex justify-content-between align-items-start mb-3">
+              <div>
+                <h2 className="h5 fw-bold mb-1">Most active companies</h2>
+                <p className="text-body-secondary small mb-0">
+                  Ranked by postings published in the last two weeks.
+                </p>
+              </div>
+            </div>
+            <BarChart
+              data={companyActivity.slice(0, 12).map((item) => ({ label: item.company, value: item.count }))}
+              ariaLabel="Companies ranked by job postings"
+              condensed
+            />
+          </section>
+        </div>
+        <div className="col-12 col-xl-6">
+          <section className="bg-white rounded-4 shadow-sm p-4 h-100">
+            <div className="d-flex justify-content-between align-items-start mb-3">
+              <div>
+                <h2 className="h5 fw-bold mb-1">Location coverage</h2>
+                <p className="text-body-secondary small mb-0">
+                  Remote mix and totals for the busiest hiring locations.
+                </p>
+              </div>
+            </div>
+            {locationRemoteStats.length === 0 ? (
+              <p className="text-body-secondary mb-0">No locations available from the current dataset.</p>
+            ) : (
+              <div className="table-responsive">
+                <table className="table table-sm align-middle mb-0">
+                  <thead>
+                    <tr>
+                      <th scope="col">Location</th>
+                      <th scope="col" className="text-end">
+                        Roles
+                      </th>
+                      <th scope="col" className="text-end">
+                        Remote share
+                      </th>
+                      <th scope="col" className="text-end">
+                        Remote
+                      </th>
+                      <th scope="col" className="text-end">
+                        On-site
+                      </th>
+                      <th scope="col" className="text-end">
+                        Unspecified
+                      </th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {locationRemoteStats.map((item) => (
+                      <tr key={item.location}>
+                        <th scope="row">{item.location}</th>
+                        <td className="text-end">{item.total}</td>
+                        <td className="text-end">{Math.round(item.remoteShare * 100)}%</td>
+                        <td className="text-end">{item.remote}</td>
+                        <td className="text-end">{item.onsite}</td>
+                        <td className="text-end">{item.unknown}</td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            )}
+          </section>
+        </div>
+      </div>
 
       <section className="bg-white rounded-4 shadow-sm p-4 p-lg-5 mb-4">
         <h2 className="h4 fw-bold mb-3">Most in-demand skills</h2>
@@ -120,7 +316,7 @@ export const AnalyticsPage = ({
       <section className="bg-white rounded-4 shadow-sm p-4 p-lg-5">
         <h2 className="h4 fw-bold mb-3">Top hiring locations</h2>
         <p className="text-body-secondary mb-4">
-          Where demand is strongest based on the current dataset. Useful for relocation planning and regional coverage.
+          Where demand is strongest based on the current dataset.
         </p>
         {locationActivity.length === 0 ? (
           <p className="text-body-secondary mb-0">No locations available from the current dataset.</p>

--- a/web/src/pages/CustomAnalyticsPage.tsx
+++ b/web/src/pages/CustomAnalyticsPage.tsx
@@ -1,0 +1,379 @@
+import { useMemo, useState } from 'react'
+import type { Job } from '../types/job'
+import { BarChart } from '../components/charts/BarChart'
+import { DonutChart } from '../components/charts/DonutChart'
+
+interface CustomAnalyticsPageProps {
+  jobs: Job[]
+  isLoading: boolean
+  error: string | null
+}
+
+type GroupingField =
+  | 'company'
+  | 'country'
+  | 'location'
+  | 'jobType'
+  | 'industry'
+  | 'currency'
+  | 'source'
+  | 'isRemote'
+  | 'techSkills'
+  | 'softSkills'
+
+type ChartType = 'table' | 'bar' | 'donut'
+
+interface WidgetConfig {
+  id: string
+  field: GroupingField
+  chartType: ChartType
+  limit: number
+}
+
+interface AggregatedDatum {
+  label: string
+  value: number
+}
+
+const GROUPING_OPTIONS: { value: GroupingField; label: string; description: string }[] = [
+  { value: 'company', label: 'Company', description: 'Hiring organisations ranked by volume.' },
+  { value: 'country', label: 'Country', description: 'Geographic distribution using inferred country.' },
+  { value: 'location', label: 'Location', description: 'City/state labels when available.' },
+  { value: 'jobType', label: 'Job type', description: 'Full-time, contract and other job types.' },
+  { value: 'industry', label: 'Industry', description: 'Company industry where provided.' },
+  { value: 'currency', label: 'Salary currency', description: 'Which currencies appear alongside salary ranges.' },
+  { value: 'source', label: 'Source', description: 'The job board or feed item originated from.' },
+  { value: 'isRemote', label: 'Remote status', description: 'Remote vs on-site vs unspecified.' },
+  { value: 'techSkills', label: 'Technical skills', description: 'Frequency of tech skills extracted from listings.' },
+  { value: 'softSkills', label: 'Soft skills', description: 'Recurring soft skills mentioned in job descriptions.' },
+]
+
+const CHART_OPTIONS: { value: ChartType; label: string }[] = [
+  { value: 'table', label: 'Table' },
+  { value: 'bar', label: 'Horizontal bar' },
+  { value: 'donut', label: 'Donut' },
+]
+
+const normalizeLabel = (value: unknown): string | null => {
+  if (value === null || value === undefined) {
+    return null
+  }
+  if (typeof value === 'string') {
+    const trimmed = value.trim()
+    return trimmed.length > 0 ? trimmed : null
+  }
+  if (typeof value === 'boolean') {
+    return value ? 'Remote' : 'On-site'
+  }
+  if (Array.isArray(value)) {
+    return value.map((item) => normalizeLabel(item)).filter(Boolean).join(', ') || null
+  }
+  return String(value)
+}
+
+const extractValues = (job: Job, field: GroupingField): string[] => {
+  switch (field) {
+    case 'company':
+      return job.company ? [job.company] : []
+    case 'country':
+      return job.country ? [job.country] : []
+    case 'location':
+      return job.location ? [job.location] : []
+    case 'jobType':
+      return job.jobType ? [job.jobType] : []
+    case 'industry':
+      return job.industry ? [job.industry] : []
+    case 'currency':
+      return job.currency ? [job.currency] : []
+    case 'source':
+      return job.source ? [job.source] : []
+    case 'isRemote':
+      if (job.isRemote === true) {
+        return ['Remote']
+      }
+      if (job.isRemote === false) {
+        return ['On-site']
+      }
+      return ['Unspecified']
+    case 'techSkills':
+      return job.techSkills
+    case 'softSkills':
+      return job.softSkills
+    default:
+      return []
+  }
+}
+
+const aggregateByField = (jobs: Job[], field: GroupingField, limit: number): AggregatedDatum[] => {
+  const counts = new Map<string, number>()
+
+  jobs.forEach((job) => {
+    const values = extractValues(job, field)
+    values.forEach((value) => {
+      const label = normalizeLabel(value)
+      if (!label) {
+        return
+      }
+      const current = counts.get(label) ?? 0
+      counts.set(label, current + 1)
+    })
+  })
+
+  return Array.from(counts.entries())
+    .map(([label, value]) => ({ label, value }))
+    .sort((a, b) => b.value - a.value || a.label.localeCompare(b.label))
+    .slice(0, limit)
+}
+
+const getFieldLabel = (field: GroupingField): string => GROUPING_OPTIONS.find((option) => option.value === field)?.label ?? field
+
+const getDefaultChartType = (field: GroupingField): ChartType => {
+  if (field === 'isRemote') {
+    return 'donut'
+  }
+  if (field === 'currency') {
+    return 'table'
+  }
+  return 'bar'
+}
+
+export const CustomAnalyticsPage = ({ jobs, isLoading, error }: CustomAnalyticsPageProps) => {
+  const [widgets, setWidgets] = useState<WidgetConfig[]>([
+    { id: 'default-company', field: 'company', chartType: 'bar', limit: 10 },
+    { id: 'default-remote', field: 'isRemote', chartType: 'donut', limit: 5 },
+  ])
+  const [selectedField, setSelectedField] = useState<GroupingField>('country')
+  const [selectedChart, setSelectedChart] = useState<ChartType>(getDefaultChartType('country'))
+  const [limit, setLimit] = useState<number>(10)
+
+  const hasData = jobs.length > 0
+
+  const aggregatedData = useMemo(() => {
+    const dataMap: Record<string, AggregatedDatum[]> = {}
+    widgets.forEach((widget) => {
+      dataMap[widget.id] = aggregateByField(jobs, widget.field, widget.limit)
+    })
+    return dataMap
+  }, [jobs, widgets])
+
+  const handleAddWidget = () => {
+    if (!selectedField) {
+      return
+    }
+    const widgetId = `${selectedField}-${Date.now()}`
+    setWidgets((current) => [
+      ...current,
+      {
+        id: widgetId,
+        field: selectedField,
+        chartType: selectedChart || getDefaultChartType(selectedField),
+        limit: Math.max(3, Math.min(50, limit || 10)),
+      },
+    ])
+  }
+
+  const handleRemoveWidget = (id: string) => {
+    setWidgets((current) => current.filter((widget) => widget.id !== id))
+  }
+
+  const updateWidget = (id: string, updates: Partial<WidgetConfig>) => {
+    setWidgets((current) => current.map((widget) => (widget.id === id ? { ...widget, ...updates } : widget)))
+  }
+
+  return (
+    <main className="py-4 py-md-5">
+      <div className="container-lg">
+        <header className="mb-4">
+          <h1 className="h2 fw-bold mb-2">Custom analytics workspace</h1>
+          <p className="text-body-secondary mb-0">
+            Build bespoke charts and tables on top of the live dataset. Combine filters, grouping dimensions and visual styles
+            to answer ad-hoc questions quickly.
+          </p>
+        </header>
+
+        <section className="bg-white rounded-4 shadow-sm p-4 p-lg-5 mb-4">
+          <h2 className="h4 fw-bold mb-3">Create a widget</h2>
+          <div className="row g-3 align-items-end">
+            <div className="col-12 col-md-4">
+              <label htmlFor="widget-field" className="form-label">
+                Group by
+              </label>
+              <select
+                id="widget-field"
+                className="form-select"
+                value={selectedField}
+                onChange={(event) => {
+                  const field = event.target.value as GroupingField
+                  setSelectedField(field)
+                  setSelectedChart(getDefaultChartType(field))
+                }}
+              >
+                {GROUPING_OPTIONS.map((option) => (
+                  <option key={option.value} value={option.value}>
+                    {option.label}
+                  </option>
+                ))}
+              </select>
+              <div className="form-text">
+                {GROUPING_OPTIONS.find((option) => option.value === selectedField)?.description}
+              </div>
+            </div>
+            <div className="col-12 col-md-3">
+              <label htmlFor="widget-chart" className="form-label">
+                Visualisation
+              </label>
+              <select
+                id="widget-chart"
+                className="form-select"
+                value={selectedChart}
+                onChange={(event) => setSelectedChart(event.target.value as ChartType)}
+              >
+                {CHART_OPTIONS.map((option) => (
+                  <option key={option.value} value={option.value}>
+                    {option.label}
+                  </option>
+                ))}
+              </select>
+            </div>
+            <div className="col-6 col-md-2">
+              <label htmlFor="widget-limit" className="form-label">
+                Rows
+              </label>
+              <input
+                id="widget-limit"
+                className="form-control"
+                type="number"
+                min={3}
+                max={50}
+                value={limit}
+                onChange={(event) => setLimit(Math.max(3, Math.min(50, Number.parseInt(event.target.value, 10) || 10)))}
+              />
+            </div>
+            <div className="col-6 col-md-3 d-grid">
+              <button
+                type="button"
+                className="btn btn-primary btn-lg fw-semibold"
+                onClick={handleAddWidget}
+                disabled={isLoading || !hasData}
+              >
+                Add widget
+              </button>
+            </div>
+          </div>
+          {!hasData && !isLoading && (
+            <p className="text-body-secondary small mb-0 mt-3">
+              Widgets appear once the jobs dataset has been loaded.
+            </p>
+          )}
+        </section>
+
+        {error && (
+          <div className="alert alert-danger rounded-4 shadow-sm" role="alert">
+            <h2 className="h5">Unable to load jobs data</h2>
+            <p className="mb-0">{error}</p>
+          </div>
+        )}
+
+        <div className="d-flex flex-column gap-4">
+          {widgets.map((widget) => {
+            const data = aggregatedData[widget.id] ?? []
+
+            const renderContent = () => {
+              if (widget.chartType === 'bar') {
+                return <BarChart data={data} ariaLabel={`${getFieldLabel(widget.field)} bar chart`} />
+              }
+              if (widget.chartType === 'donut') {
+                return (
+                  <DonutChart
+                    segments={data.map((item) => ({ label: item.label, value: item.value }))}
+                    ariaLabel={`${getFieldLabel(widget.field)} donut chart`}
+                  />
+                )
+              }
+              return (
+                <div className="table-responsive">
+                  <table className="table table-sm align-middle mb-0">
+                    <thead>
+                      <tr>
+                        <th scope="col">Value</th>
+                        <th scope="col" className="text-end">
+                          Roles
+                        </th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {data.map((item) => (
+                        <tr key={item.label}>
+                          <th scope="row">{item.label}</th>
+                          <td className="text-end">{item.value}</td>
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
+                </div>
+              )
+            }
+
+            return (
+              <section key={widget.id} className="bg-white rounded-4 shadow-sm p-4 p-lg-5">
+                <div className="d-flex flex-wrap gap-3 justify-content-between align-items-start mb-3">
+                  <div>
+                    <h2 className="h4 fw-bold mb-1">{getFieldLabel(widget.field)}</h2>
+                    <p className="text-body-secondary small mb-0">
+                      {GROUPING_OPTIONS.find((option) => option.value === widget.field)?.description}
+                    </p>
+                  </div>
+                  <div className="d-flex flex-wrap gap-2 align-items-center">
+                    <label className="form-label mb-0 me-2 text-body-secondary small" htmlFor={`chart-${widget.id}`}>
+                      Visual
+                    </label>
+                    <select
+                      id={`chart-${widget.id}`}
+                      className="form-select form-select-sm"
+                      value={widget.chartType}
+                      onChange={(event) => updateWidget(widget.id, { chartType: event.target.value as ChartType })}
+                    >
+                      {CHART_OPTIONS.map((option) => (
+                        <option key={option.value} value={option.value}>
+                          {option.label}
+                        </option>
+                      ))}
+                    </select>
+                    <label className="form-label mb-0 ms-3 me-2 text-body-secondary small" htmlFor={`limit-${widget.id}`}>
+                      Rows
+                    </label>
+                    <input
+                      id={`limit-${widget.id}`}
+                      className="form-control form-control-sm"
+                      type="number"
+                      min={3}
+                      max={50}
+                      value={widget.limit}
+                      onChange={(event) =>
+                        updateWidget(widget.id, {
+                          limit: Math.max(3, Math.min(50, Number.parseInt(event.target.value, 10) || widget.limit)),
+                        })
+                      }
+                    />
+                    <button
+                      type="button"
+                      className="btn btn-outline-danger btn-sm"
+                      onClick={() => handleRemoveWidget(widget.id)}
+                    >
+                      Remove
+                    </button>
+                  </div>
+                </div>
+                {data.length === 0 ? (
+                  <p className="text-body-secondary mb-0">No data available for this widget.</p>
+                ) : (
+                  renderContent()
+                )}
+              </section>
+            )
+          })}
+        </div>
+      </div>
+    </main>
+  )
+}

--- a/web/src/pages/HomePage.tsx
+++ b/web/src/pages/HomePage.tsx
@@ -42,35 +42,33 @@ export const HomePage = ({
 }: HomePageProps) => (
   <main className="py-4 py-md-5">
     <div className="container-lg">
-
-     <header className="hero bg-primary text-white rounded-5 p-4 p-lg-5 mb-5 shadow-sm">
-        <div className="row align-items-center g-4">
-          <div className="col-lg-9 col-xl-8 text-center text-lg-start mx-lg-auto">
-            <span className="badge bg-white text-primary fw-semibold text-uppercase mb-3">
-              Middle East · Data Engineering
-            </span>
-            <h1 className="hero__title fw-bold mb-3">Find your next data engineering role in minutes</h1>
-            <p className="hero__subtitle lead mb-4 text-white-50">
-              Browse vetted opportunities from Riyadh to Dubai and instantly filter by location or posting date. Build a
-              personalised shortlist using smart keyword combinations.
+      <header className="mb-4">
+        <div className="d-flex flex-column flex-lg-row gap-3 gap-lg-4 align-items-lg-center justify-content-between">
+          <div className="flex-grow-1">
+            <h1 className="h2 fw-bold mb-2">Middle East data engineering roles</h1>
+            <p className="text-body-secondary mb-0">
+              A concise feed of vetted openings updated continuously. Apply filters to interrogate {jobs.length} listings and
+              surface the {filteredJobs.length} roles that match your criteria.
             </p>
-            <div className="hero__actions d-flex flex-column flex-sm-row gap-3 align-items-stretch align-items-sm-center">
-              <a className="btn btn-light btn-lg text-primary fw-semibold shadow-sm" href="#job-results">
-                Browse open roles
-              </a>
-              <Link className="btn btn-outline-light btn-lg fw-semibold" to="/analytics">
-                View market analytics
-              </Link>
-              <div className="hero__actions-note small text-white-50 text-start text-sm-center text-lg-start">
-                <span className="d-block fw-semibold text-white">Focused results</span>
-                Multi-select search and posting date filters keep the board tailored to your next move.
-              </div>
-            </div>
           </div>
+          <div className="d-flex flex-wrap gap-2">
+            <a className="btn btn-primary fw-semibold" href="#job-results">
+              Jump to results
+            </a>
+            <Link className="btn btn-outline-primary fw-semibold" to="/analytics">
+              View analytics
+            </Link>
+          </div>
+        </div>
+        <div className="d-flex flex-wrap gap-3 mt-3 text-body-secondary small">
+          <span className="fw-semibold text-body">
+            {isLoading ? 'Refreshing data…' : `${metrics.total} live roles · ${metrics.remote} remote`}
+          </span>
+          <span>Hiring companies: {isLoading ? '—' : metrics.companies}</span>
+          <span>Regional coverage: {isLoading ? '—' : `${metrics.countries} countries`}</span>
         </div>
       </header>
 
-      
       {error && (
         <div className="alert alert-danger rounded-4 shadow-sm" role="alert">
           <h2 className="h5">We couldn’t load the latest opportunities</h2>

--- a/web/src/utils/analytics.ts
+++ b/web/src/utils/analytics.ts
@@ -10,6 +10,41 @@ export interface LocationActivity {
   count: number
 }
 
+export interface WeeklyTrendPoint {
+  weekStart: string
+  label: string
+  total: number
+  remote: number
+}
+
+export interface RemoteSplitSegment {
+  label: string
+  count: number
+}
+
+export interface SalaryBenchmark {
+  currency: string
+  roles: number
+  average: number
+  minimum: number
+  maximum: number
+}
+
+export interface IndustryBreakdown {
+  industry: string
+  roles: number
+  remoteShare: number
+}
+
+export interface LocationRemoteStat {
+  location: string
+  total: number
+  remote: number
+  onsite: number
+  unknown: number
+  remoteShare: number
+}
+
 const isWithinWindow = (job: Job, days: number): boolean => {
   if (!job.postingDate) {
     return false
@@ -62,5 +97,186 @@ export const buildLocationActivity = (jobs: Job[], limit = 5): LocationActivity[
   return Array.from(counts.entries())
     .map(([location, count]) => ({ location, count }))
     .sort((a, b) => b.count - a.count || a.location.localeCompare(b.location))
+    .slice(0, limit)
+}
+
+const getWeekStart = (date: Date): Date => {
+  const weekStart = new Date(date)
+  const day = weekStart.getUTCDay() || 7
+  if (day !== 1) {
+    weekStart.setUTCDate(weekStart.getUTCDate() + 1 - day)
+  }
+  weekStart.setUTCHours(0, 0, 0, 0)
+  return weekStart
+}
+
+export const buildPostingTrends = (jobs: Job[], weeks = 12): WeeklyTrendPoint[] => {
+  const trend = new Map<string, { total: number; remote: number }>()
+
+  jobs.forEach((job) => {
+    if (!job.postingDate) {
+      return
+    }
+
+    const parsed = new Date(job.postingDate)
+    if (Number.isNaN(parsed.getTime())) {
+      return
+    }
+
+    const weekStart = getWeekStart(parsed)
+    const key = weekStart.toISOString()
+    const current = trend.get(key) ?? { total: 0, remote: 0 }
+    current.total += 1
+    if (job.isRemote === true) {
+      current.remote += 1
+    }
+    trend.set(key, current)
+  })
+
+  return Array.from(trend.entries())
+    .sort(([a], [b]) => (a < b ? -1 : 1))
+    .slice(-weeks)
+    .map(([weekStart, counts]) => ({
+      weekStart,
+      label: new Intl.DateTimeFormat(undefined, { month: 'short', day: 'numeric' }).format(new Date(weekStart)),
+      total: counts.total,
+      remote: counts.remote,
+    }))
+}
+
+export const buildRemoteSplit = (jobs: Job[]): RemoteSplitSegment[] => {
+  let remote = 0
+  let onsite = 0
+  let unknown = 0
+
+  jobs.forEach((job) => {
+    if (job.isRemote === true) {
+      remote += 1
+    } else if (job.isRemote === false) {
+      onsite += 1
+    } else {
+      unknown += 1
+    }
+  })
+
+  return [
+    { label: 'Remote', count: remote },
+    { label: 'On-site', count: onsite },
+    { label: 'Unspecified', count: unknown },
+  ].filter((segment) => segment.count > 0)
+}
+
+export const buildSalaryBenchmarks = (jobs: Job[]): SalaryBenchmark[] => {
+  const byCurrency = new Map<string, { values: number[]; min: number; max: number }>()
+
+  jobs.forEach((job) => {
+    if (!job.currency) {
+      return
+    }
+
+    const hasMin = typeof job.minSalary === 'number'
+    const hasMax = typeof job.maxSalary === 'number'
+
+    if (!hasMin && !hasMax) {
+      return
+    }
+
+    const midpoint = hasMin && hasMax ? (job.minSalary! + job.maxSalary!) / 2 : (job.minSalary ?? job.maxSalary ?? 0)
+    const entry = byCurrency.get(job.currency) ?? { values: [], min: Number.POSITIVE_INFINITY, max: Number.NEGATIVE_INFINITY }
+    entry.values.push(midpoint)
+    if (hasMin) {
+      entry.min = Math.min(entry.min, job.minSalary!)
+    }
+    if (hasMax) {
+      entry.max = Math.max(entry.max, job.maxSalary!)
+    }
+    byCurrency.set(job.currency, entry)
+  })
+
+  return Array.from(byCurrency.entries())
+    .map(([currency, { values, min, max }]) => ({
+      currency,
+      roles: values.length,
+      average: values.reduce((acc, value) => acc + value, 0) / values.length,
+      minimum: Number.isFinite(min) ? min : 0,
+      maximum: Number.isFinite(max) ? max : 0,
+    }))
+    .filter((item) => item.roles > 0)
+    .sort((a, b) => b.roles - a.roles || a.currency.localeCompare(b.currency))
+}
+
+const cleanIndustryLabel = (job: Job): string | null => {
+  if (job.industry) {
+    return job.industry
+  }
+
+  if (job.domains) {
+    return job.domains
+      .split(',')
+      .map((item) => item.trim())
+      .filter(Boolean)[0] ?? null
+  }
+
+  return null
+}
+
+export const buildIndustryBreakdown = (jobs: Job[], limit = 8): IndustryBreakdown[] => {
+  const buckets = new Map<string, { total: number; remote: number }>()
+
+  jobs.forEach((job) => {
+    const label = cleanIndustryLabel(job)
+    if (!label) {
+      return
+    }
+
+    const bucket = buckets.get(label) ?? { total: 0, remote: 0 }
+    bucket.total += 1
+    if (job.isRemote === true) {
+      bucket.remote += 1
+    }
+    buckets.set(label, bucket)
+  })
+
+  return Array.from(buckets.entries())
+    .map(([industry, { total, remote }]) => ({
+      industry,
+      roles: total,
+      remoteShare: total > 0 ? remote / total : 0,
+    }))
+    .sort((a, b) => b.roles - a.roles || a.industry.localeCompare(b.industry))
+    .slice(0, limit)
+}
+
+export const buildLocationRemoteStats = (jobs: Job[], limit = 8): LocationRemoteStat[] => {
+  const stats = new Map<string, { total: number; remote: number; onsite: number; unknown: number }>()
+
+  jobs.forEach((job) => {
+    const label = job.country ?? job.location
+    if (!label) {
+      return
+    }
+
+    const entry = stats.get(label) ?? { total: 0, remote: 0, onsite: 0, unknown: 0 }
+    entry.total += 1
+    if (job.isRemote === true) {
+      entry.remote += 1
+    } else if (job.isRemote === false) {
+      entry.onsite += 1
+    } else {
+      entry.unknown += 1
+    }
+    stats.set(label, entry)
+  })
+
+  return Array.from(stats.entries())
+    .map(([location, { total, remote, onsite, unknown }]) => ({
+      location,
+      total,
+      remote,
+      onsite,
+      unknown,
+      remoteShare: total > 0 ? remote / total : 0,
+    }))
+    .sort((a, b) => b.total - a.total || a.location.localeCompare(b.location))
     .slice(0, limit)
 }


### PR DESCRIPTION
## Summary
- replace the home page hero with a compact summary that highlights key metrics
- expand the talent analytics dashboard with trend charts, salary benchmarks, and location/industry tables
- add a configurable custom analytics workspace backed by reusable SVG chart components and new analytics helpers

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68eaadfafde883328c05293cd56cb917